### PR TITLE
デザインシステムに影を追加

### DIFF
--- a/app/(tabs)/design-system.tsx
+++ b/app/(tabs)/design-system.tsx
@@ -7,7 +7,8 @@ import { ThemedView } from '@/components/themed-view';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { IconSymbol } from '@/components/ui/icon-symbol';
-import { ColorPalette } from '@/constants/design-tokens';
+import { ColorPalette, Shadow } from '@/constants/design-tokens';
+import { useTheme } from '@/hooks/use-theme';
 
 export default function DesignSystemScreen() {
   return (
@@ -50,6 +51,12 @@ export default function DesignSystemScreen() {
       <ThemedView style={styles.section}>
         <ThemedText type="h3">Spacing & Layout</ThemedText>
         <SpacingShowcase />
+      </ThemedView>
+
+      {/* Shadow Section */}
+      <ThemedView style={styles.section}>
+        <ThemedText type="h3">Shadows</ThemedText>
+        <ShadowShowcase />
       </ThemedView>
     </ParallaxScrollView>
   );
@@ -233,6 +240,47 @@ function SpacingShowcase() {
   );
 }
 
+function ShadowShowcase() {
+  const { theme } = useTheme();
+  const shadowLevels = [
+    { name: 'sm', shadow: Shadow.sm, description: 'Subtle shadow for small elements' },
+    { name: 'base', shadow: Shadow.base, description: 'Default shadow for cards' },
+    { name: 'md', shadow: Shadow.md, description: 'Medium shadow for elevated content' },
+    { name: 'lg', shadow: Shadow.lg, description: 'Large shadow for modals' },
+    { name: 'xl', shadow: Shadow.xl, description: 'Extra large shadow for overlays' },
+    { name: '2xl', shadow: Shadow['2xl'], description: 'Maximum shadow for dropdowns' },
+  ];
+
+  return (
+    <ThemedView>
+      {shadowLevels.map((level) => (
+        <View key={level.name} style={styles.shadowItem}>
+          <View
+            style={[
+              styles.shadowBox,
+              {
+                backgroundColor: theme.background.elevated,
+                ...level.shadow,
+              }
+            ]}
+          >
+            <ThemedText type="h6">{level.name}</ThemedText>
+            <ThemedText type="caption" style={styles.shadowDescription}>
+              {level.description}
+            </ThemedText>
+            <ThemedText type="caption" style={styles.shadowValues}>
+              offset: {level.shadow.shadowOffset.width}, {level.shadow.shadowOffset.height} |{' '}
+              opacity: {level.shadow.shadowOpacity} |{' '}
+              radius: {level.shadow.shadowRadius} |{' '}
+              elevation: {level.shadow.elevation}
+            </ThemedText>
+          </View>
+        </View>
+      ))}
+    </ThemedView>
+  );
+}
+
 const styles = StyleSheet.create({
   headerImage: {
     color: '#0ea5e9',
@@ -308,5 +356,24 @@ const styles = StyleSheet.create({
   },
   cardExample: {
     marginBottom: 8,
+  },
+  shadowItem: {
+    marginBottom: 20,
+  },
+  shadowBox: {
+    padding: 16,
+    borderRadius: 8,
+    minHeight: 80,
+    justifyContent: 'center',
+  },
+  shadowDescription: {
+    marginTop: 4,
+    opacity: 0.7,
+  },
+  shadowValues: {
+    marginTop: 4,
+    opacity: 0.5,
+    fontSize: 10,
+    fontFamily: 'monospace',
   },
 });

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -66,6 +66,12 @@ export const LightTheme = {
     iconSelected: ColorPalette.primary[600],
     tint: ColorPalette.primary[600],
   },
+
+  // Shadow Colors
+  shadow: {
+    color: "rgba(0, 0, 0, 0.15)",
+    androidColor: "rgba(0, 0, 0, 0.3)",
+  },
 } as const;
 
 // Dark Theme
@@ -125,6 +131,12 @@ export const DarkTheme = {
     iconDefault: ColorPalette.neutral[400],
     iconSelected: "#ffffff",
     tint: "#ffffff",
+  },
+
+  // Shadow Colors
+  shadow: {
+    color: "rgba(0, 0, 0, 0.25)",
+    androidColor: "rgba(0, 0, 0, 0.4)",
   },
 } as const;
 


### PR DESCRIPTION
## 概要

issue#5の対応として、デザインシステムに影（Shadow）の機能を追加しました。

## 変更内容

- **テーマシステムの拡張**: `constants/theme.ts`にライト/ダークモード対応のシャドウカラーを追加
- **デザインシステム画面の拡張**: デバッグ用のシャドウ一覧表示セクションを追加
- **視覚的なデモ**: 6段階のシャドウレベル（sm, base, md, lg, xl, 2xl）を実際の効果と共に表示
- **開発者体験の向上**: 各シャドウの技術的な値（offset、opacity、radius、elevation）を表示

## テスト計画

- [x] ESLintチェック通過
- [ ] iOS/Android両方でのシャドウ表示確認
- [ ] ライト/ダークモード切り替えでのシャドウカラー適用確認
- [ ] デザインシステム画面での各シャドウレベルの表示確認

## 影響範囲

- 既存機能への影響なし（additive change）
- 新しいテーマプロパティの追加により、今後のコンポーネントでシャドウ活用が容易に

🤖 Generated with [Claude Code](https://claude.ai/code)