### PR TITLE
Cardコンポーネントをshadcnライクに修正

### DIFF
--- a/app/(tabs)/design-system.tsx
+++ b/app/(tabs)/design-system.tsx
@@ -5,7 +5,7 @@ import ParallaxScrollView from '@/components/parallax-scroll-view';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
 import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { ColorPalette, Shadow, BorderRadius } from '@/constants/design-tokens';
 import { useTheme } from '@/hooks/use-theme';
@@ -201,39 +201,57 @@ function CardShowcase() {
       <ThemedText type="h6">Variants</ThemedText>
       <View style={styles.cardGrid}>
         <Card variant="elevated" style={styles.cardExample}>
-          <ThemedText type="h6">Elevated Card</ThemedText>
-          <ThemedText type="body">Card with shadow elevation</ThemedText>
+          <CardHeader>
+            <CardTitle>Elevated Card</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ThemedText type="body">Card with shadow elevation</ThemedText>
+          </CardContent>
         </Card>
         
         <Card variant="flat" style={styles.cardExample}>
-          <ThemedText type="h6">Flat Card</ThemedText>
-          <ThemedText type="body">Card with background color</ThemedText>
+          <CardHeader>
+            <CardTitle>Flat Card</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ThemedText type="body">Card with background color</ThemedText>
+          </CardContent>
         </Card>
         
         <Card variant="outlined" style={styles.cardExample}>
-          <ThemedText type="h6">Outlined Card</ThemedText>
-          <ThemedText type="body">Card with border outline</ThemedText>
+          <CardHeader>
+            <CardTitle>Outlined Card</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ThemedText type="body">Card with border outline</ThemedText>
+          </CardContent>
         </Card>
       </View>
       
-      <ThemedText type="h6" style={{ marginTop: 16 }}>Padding Options</ThemedText>
-      <View style={styles.cardGrid}>
-        <Card padding="small" style={styles.cardExample}>
-          <ThemedText type="caption">Small Padding</ThemedText>
-        </Card>
-        
-        <Card padding="medium" style={styles.cardExample}>
-          <ThemedText type="caption">Medium Padding</ThemedText>
-        </Card>
-        
-        <Card padding="large" style={styles.cardExample}>
-          <ThemedText type="caption">Large Padding</ThemedText>
-        </Card>
-        
-        <Card padding="none" style={[styles.cardExample, { padding: 8 }]}>
-          <ThemedText type="caption">No Padding</ThemedText>
-        </Card>
-      </View>
+      <ThemedText type="h6" style={{ marginTop: 16 }}>Structured Card Example</ThemedText>
+      <Card variant="elevated" style={styles.cardExample}>
+        <CardHeader>
+          <CardTitle>User Profile</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ThemedText type="body">This is an example of a structured card using the new Card components.</ThemedText>
+          <ThemedText type="caption" style={{ marginTop: 8 }}>Created with CardHeader, CardTitle, and CardContent</ThemedText>
+        </CardContent>
+      </Card>
+      
+      <ThemedText type="h6" style={{ marginTop: 16 }}>Header Only Card</ThemedText>
+      <Card variant="outlined" style={styles.cardExample}>
+        <CardHeader>
+          <CardTitle>Simple Header Card</CardTitle>
+        </CardHeader>
+      </Card>
+      
+      <ThemedText type="h6" style={{ marginTop: 16 }}>Content Only Card</ThemedText>
+      <Card variant="flat" style={styles.cardExample}>
+        <CardContent>
+          <ThemedText type="body">This card only has content without a header.</ThemedText>
+        </CardContent>
+      </Card>
     </ThemedView>
   );
 }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,17 +1,24 @@
 import { View, type ViewProps } from "react-native";
 import { ComponentStyles } from "@/constants/styles";
 import { useTheme } from "@/hooks/use-theme";
+import { ThemedText } from "@/components/themed-text";
 
 export type CardVariant = "elevated" | "flat" | "outlined";
 
 export type CardProps = ViewProps & {
   variant?: CardVariant;
-  padding?: "none" | "small" | "medium" | "large";
 };
+
+export type CardHeaderProps = ViewProps;
+
+export type CardTitleProps = ViewProps & {
+  children: React.ReactNode;
+};
+
+export type CardContentProps = ViewProps;
 
 export function Card({
   variant = "elevated",
-  padding = "medium",
   style,
   children,
   ...rest
@@ -42,22 +49,44 @@ export function Card({
     }
   };
 
-  const getPaddingOverride = () => {
-    switch (padding) {
-      case "none":
-        return { padding: 0 };
-      case "small":
-        return { padding: 12 };
-      case "large":
-        return { padding: 24 };
-      case "medium":
-      default:
-        return {};
-    }
-  };
-
   return (
-    <View style={[getVariantStyles(), getPaddingOverride(), style]} {...rest}>
+    <View style={[getVariantStyles(), style]} {...rest}>
+      {children}
+    </View>
+  );
+}
+
+export function CardHeader({
+  style,
+  children,
+  ...rest
+}: CardHeaderProps) {
+  return (
+    <View style={[{ paddingBottom: 16 }, style]} {...rest}>
+      {children}
+    </View>
+  );
+}
+
+export function CardTitle({
+  style,
+  children,
+  ...rest
+}: CardTitleProps) {
+  return (
+    <View style={[style]} {...rest}>
+      <ThemedText type="h6">{children}</ThemedText>
+    </View>
+  );
+}
+
+export function CardContent({
+  style,
+  children,
+  ...rest
+}: CardContentProps) {
+  return (
+    <View style={[{ padding: 16 }, style]} {...rest}>
       {children}
     </View>
   );


### PR DESCRIPTION
## Summary
- CardコンポーネントをshadcnのCardコンポーネントのような構造に変更
- Card, CardHeader, CardTitle, CardContentに分離して使いやすく
- デザインシステムのショーケースを新しいコンポーネント構造に更新

## 変更内容
- `Card`コンポーネントからpadding propsを削除し、よりシンプルに
- `CardHeader`コンポーネントを追加（下部にpaddingを持つ）
- `CardTitle`コンポーネントを追加（h6タイプのThemedTextをラップ）
- `CardContent`コンポーネントを追加（16pxのpaddingを持つ）
- ショーケースに構造化されたカードの例を追加

## Test plan
- [ ] アプリを起動し、Design Systemタブを確認
- [ ] Cardセクションで新しいコンポーネント構造が表示されることを確認
- [ ] 各カードが正しく表示されることを確認
- [ ] 構造化されたカードの使用例が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)