### PR TITLE
Dialogコンポーネントにvariant機能を追加

### DIFF
--- a/app/(tabs)/design-system.tsx
+++ b/app/(tabs)/design-system.tsx
@@ -376,6 +376,7 @@ function DialogShowcase() {
   const [basicDialogOpen, setBasicDialogOpen] = useState(false);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [customDialogOpen, setCustomDialogOpen] = useState(false);
+  const [noOverlayDialogOpen, setNoOverlayDialogOpen] = useState(false);
 
   return (
     <ThemedView style={styles.componentSection}>
@@ -424,6 +425,36 @@ function DialogShowcase() {
             </DialogClose>
             <DialogClose onPress={() => console.log('Item deleted')}>
               <Button title="Delete" variant="primary" />
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <ThemedText type="h6" style={{ marginTop: 16 }}>No Overlay Dialog</ThemedText>
+      <Dialog open={noOverlayDialogOpen} onOpenChange={setNoOverlayDialogOpen} variant="no-overlay">
+        <DialogTrigger>
+          <Button 
+            title="Open No Overlay Dialog" 
+            variant="ghost"
+            onPress={() => setNoOverlayDialogOpen(true)} 
+          />
+        </DialogTrigger>
+        <DialogContent>
+          <DialogClose />
+          <DialogHeader>
+            <DialogTitle>No Overlay Dialog</DialogTitle>
+            <DialogDescription>
+              This dialog has no background overlay and must be closed with the button.
+            </DialogDescription>
+          </DialogHeader>
+          <View style={{ paddingVertical: 16 }}>
+            <ThemedText type="body">
+              Since there&apos;s no overlay, clicking outside won&apos;t close this dialog. Use the close button or footer buttons to dismiss it.
+            </ThemedText>
+          </View>
+          <DialogFooter>
+            <DialogClose>
+              <Button title="Close" variant="primary" />
             </DialogClose>
           </DialogFooter>
         </DialogContent>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -16,6 +16,7 @@ export type DialogProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   children: React.ReactNode;
+  variant?: "default" | "no-overlay";
 };
 
 export type DialogContentProps = ViewProps & {
@@ -46,14 +47,16 @@ export type DialogCloseProps = {
 const DialogContext = React.createContext<{
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  variant?: "default" | "no-overlay";
 }>({
   open: false,
   onOpenChange: () => {},
+  variant: "default",
 });
 
-export function Dialog({ open, onOpenChange, children }: DialogProps) {
+export function Dialog({ open, onOpenChange, children, variant = "default" }: DialogProps) {
   return (
-    <DialogContext.Provider value={{ open, onOpenChange }}>
+    <DialogContext.Provider value={{ open, onOpenChange, variant }}>
       {children}
     </DialogContext.Provider>
   );
@@ -69,11 +72,48 @@ export function DialogContent({
   ...rest
 }: DialogContentProps) {
   const { theme } = useTheme();
-  const { open, onOpenChange } = React.useContext(DialogContext);
+  const { open, onOpenChange, variant } = React.useContext(DialogContext);
 
   const handleBackdropPress = () => {
     onOpenChange(false);
   };
+
+  if (variant === "no-overlay") {
+    return (
+      <Modal
+        visible={open}
+        transparent
+        animationType="fade"
+        onRequestClose={() => onOpenChange(false)}
+      >
+        <View
+          style={{
+            flex: 1,
+            alignItems: "center",
+            justifyContent: "center",
+            padding: Spacing[4],
+          }}
+        >
+          <View
+            style={[
+              {
+                backgroundColor: theme.background.elevated,
+                borderRadius: BorderRadius.xl,
+                padding: Spacing[6],
+                minWidth: 280,
+                maxWidth: "90%",
+                ...Shadow.lg,
+              },
+              style,
+            ]}
+            {...rest}
+          >
+            {children}
+          </View>
+        </View>
+      </Modal>
+    );
+  }
 
   return (
     <Modal


### PR DESCRIPTION
## 概要
DialogコンポーネントにvariantプロパティでDialog表示スタイルを切り替えられる機能を追加しました。

## 変更内容
- `DialogProps`に`variant?: "default" | "no-overlay"`を追加
- `variant="no-overlay"`の場合はオーバーレイなしでダイアログを表示
- デザインシステムページに`no-overlay`ダイアログのショーケースを追加

## 主な変更点
- `components/ui/dialog.tsx`: variant機能の実装
- `app/(tabs)/design-system.tsx`: ショーケースの追加

## テスト計画
- [ ] デフォルト（オーバーレイあり）ダイアログの動作確認
- [ ] no-overlayダイアログの動作確認
- [ ] 背景クリックでの閉じる動作の違いを確認
- [ ] 各種端末（iOS/Android/Web）での表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)