### PR TITLE
feat: UIディレクトリにTabコンポーネントを追加

### DIFF
--- a/app/(tabs)/design-system.tsx
+++ b/app/(tabs)/design-system.tsx
@@ -8,6 +8,7 @@ import { ThemedView } from '@/components/themed-view';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from '@/components/ui/dialog';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { TextInput } from '@/components/ui/text-input';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { ColorPalette, Shadow, BorderRadius } from '@/constants/design-tokens';
@@ -150,6 +151,9 @@ function ComponentShowcase() {
       </Collapsible>
       <Collapsible title="Dialogs">
         <DialogShowcase />
+      </Collapsible>
+      <Collapsible title="Tabs">
+        <TabsShowcase />
       </Collapsible>
       <Collapsible title="Text Inputs">
         <TextInputShowcase />
@@ -584,6 +588,120 @@ function TextInputShowcase() {
         placeholder="Full width input"
         fullWidth
       />
+    </ThemedView>
+  );
+}
+
+function TabsShowcase() {
+  return (
+    <ThemedView style={styles.componentSection}>
+      <ThemedText type="h6">Basic Tabs Example</ThemedText>
+      <Tabs defaultValue="overview" style={{ marginTop: 8 }}>
+        <TabsList>
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="details">Details</TabsTrigger>
+          <TabsTrigger value="settings">Settings</TabsTrigger>
+        </TabsList>
+        <TabsContent value="overview">
+          <ThemedText type="body">
+            This is the overview content. The Tab component provides a clean way to organize content into sections.
+          </ThemedText>
+        </TabsContent>
+        <TabsContent value="details">
+          <ThemedText type="body">
+            This is the details content. You can switch between tabs by tapping on the triggers above.
+          </ThemedText>
+        </TabsContent>
+        <TabsContent value="settings">
+          <ThemedText type="body">
+            This is the settings content. The active tab has a dark badge style while inactive tabs have a light style.
+          </ThemedText>
+        </TabsContent>
+      </Tabs>
+
+      <ThemedText type="h6" style={{ marginTop: 24 }}>Many Tabs with Horizontal Scroll</ThemedText>
+      <Tabs defaultValue="tab1" style={{ marginTop: 8 }}>
+        <TabsList>
+          <TabsTrigger value="tab1">タブ1</TabsTrigger>
+          <TabsTrigger value="tab2">タブ2</TabsTrigger>
+          <TabsTrigger value="tab3">タブ3</TabsTrigger>
+          <TabsTrigger value="tab4">タブ4</TabsTrigger>
+          <TabsTrigger value="tab5">タブ5</TabsTrigger>
+          <TabsTrigger value="tab6">タブ6</TabsTrigger>
+          <TabsTrigger value="tab7">Very Long Tab Name</TabsTrigger>
+          <TabsTrigger value="tab8">Tab 8</TabsTrigger>
+        </TabsList>
+        <TabsContent value="tab1">
+          <ThemedText type="body">コンテンツ 1 - 横スクロールが動作することを確認できます。</ThemedText>
+        </TabsContent>
+        <TabsContent value="tab2">
+          <ThemedText type="body">コンテンツ 2 - タブが多い場合の動作を確認。</ThemedText>
+        </TabsContent>
+        <TabsContent value="tab3">
+          <ThemedText type="body">コンテンツ 3</ThemedText>
+        </TabsContent>
+        <TabsContent value="tab4">
+          <ThemedText type="body">コンテンツ 4</ThemedText>
+        </TabsContent>
+        <TabsContent value="tab5">
+          <ThemedText type="body">コンテンツ 5</ThemedText>
+        </TabsContent>
+        <TabsContent value="tab6">
+          <ThemedText type="body">コンテンツ 6</ThemedText>
+        </TabsContent>
+        <TabsContent value="tab7">
+          <ThemedText type="body">コンテンツ 7 - 長いタブ名の場合</ThemedText>
+        </TabsContent>
+        <TabsContent value="tab8">
+          <ThemedText type="body">コンテンツ 8</ThemedText>
+        </TabsContent>
+      </Tabs>
+
+      <ThemedText type="h6" style={{ marginTop: 24 }}>Controlled Tabs</ThemedText>
+      <Tabs defaultValue="home" style={{ marginTop: 8 }}>
+        <TabsList>
+          <TabsTrigger value="home">Home</TabsTrigger>
+          <TabsTrigger value="profile">Profile</TabsTrigger>
+          <TabsTrigger value="messages">Messages</TabsTrigger>
+          <TabsTrigger value="notifications">Notifications</TabsTrigger>
+        </TabsList>
+        <TabsContent value="home">
+          <Card variant="flat" style={{ marginTop: 8 }}>
+            <CardContent>
+              <ThemedText type="body">
+                Welcome to your home dashboard. Here you can see an overview of your recent activity.
+              </ThemedText>
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="profile">
+          <Card variant="flat" style={{ marginTop: 8 }}>
+            <CardContent>
+              <ThemedText type="body">
+                Manage your profile settings and personal information here.
+              </ThemedText>
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="messages">
+          <Card variant="flat" style={{ marginTop: 8 }}>
+            <CardContent>
+              <ThemedText type="body">
+                Your messages and conversations appear in this section.
+              </ThemedText>
+            </CardContent>
+          </Card>
+        </TabsContent>
+        <TabsContent value="notifications">
+          <Card variant="flat" style={{ marginTop: 8 }}>
+            <CardContent>
+              <ThemedText type="body">
+                Check your latest notifications and alerts here.
+              </ThemedText>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
     </ThemedView>
   );
 }

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -6,6 +6,7 @@ export { Button } from './button';
 export { Card } from './card';
 export { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from './dialog';
 export { Spacing } from './spacing';
+export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';
 export { TextInput } from './text-input';
 
 // Re-export existing components

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -1,0 +1,199 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import {
+  View,
+  TouchableOpacity,
+  ScrollView,
+  type ViewProps,
+  type ScrollViewProps,
+  type TouchableOpacityProps,
+} from 'react-native';
+import { ThemedText } from '@/components/themed-text';
+import { TypographyStyles } from '@/constants/styles';
+import { ColorPalette, Spacing, BorderRadius } from '@/constants/design-tokens';
+
+// Context for managing tab state
+type TabsContextType = {
+  activeTab: string;
+  onTabChange: (value: string) => void;
+};
+
+const TabsContext = createContext<TabsContextType | null>(null);
+
+function useTabsContext() {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error('Tab components must be used within a Tabs component');
+  }
+  return context;
+}
+
+// Type definitions
+export type TabsProps = ViewProps & {
+  defaultValue: string;
+  value?: string;
+  onValueChange?: (value: string) => void;
+  children: React.ReactNode;
+};
+
+export type TabsListProps = ScrollViewProps & {
+  children: React.ReactNode;
+};
+
+export type TabsTriggerProps = TouchableOpacityProps & {
+  value: string;
+  children: React.ReactNode;
+};
+
+export type TabsContentProps = ViewProps & {
+  value: string;
+  children: React.ReactNode;
+};
+
+// Main Tabs component
+export function Tabs({
+  defaultValue,
+  value,
+  onValueChange,
+  children,
+  style,
+  ...rest
+}: TabsProps) {
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const activeTab = value ?? internalValue;
+
+  const handleTabChange = useCallback(
+    (newValue: string) => {
+      if (value === undefined) {
+        setInternalValue(newValue);
+      }
+      onValueChange?.(newValue);
+    },
+    [value, onValueChange]
+  );
+
+  return (
+    <TabsContext.Provider value={{ activeTab, onTabChange: handleTabChange }}>
+      <View style={[{ flex: 1 }, style]} {...rest}>
+        {children}
+      </View>
+    </TabsContext.Provider>
+  );
+}
+
+// TabsList component with horizontal scrolling
+export function TabsList({ children, style, ...rest }: TabsListProps) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={{
+        paddingHorizontal: Spacing[4],
+        gap: Spacing[2],
+        alignItems: 'center',
+      }}
+      style={[
+        {
+          flexGrow: 0,
+          paddingVertical: Spacing[2],
+        },
+        style,
+      ]}
+      {...rest}
+    >
+      {children}
+    </ScrollView>
+  );
+}
+
+// TabsTrigger component with badge styling
+export function TabsTrigger({
+  value,
+  children,
+  style,
+  disabled,
+  ...rest
+}: TabsTriggerProps) {
+  const { activeTab, onTabChange } = useTabsContext();
+  const isActive = activeTab === value;
+
+  const getBadgeStyles = () => {
+    if (isActive) {
+      return {
+        backgroundColor: ColorPalette.neutral[900],
+        borderColor: ColorPalette.neutral[900],
+      };
+    }
+    return {
+      backgroundColor: ColorPalette.neutral[100],
+      borderColor: ColorPalette.neutral[200],
+    };
+  };
+
+  const getTextColor = () => {
+    if (disabled) return ColorPalette.neutral[400];
+    if (isActive) return '#ffffff';
+    return ColorPalette.neutral[700];
+  };
+
+  return (
+    <TouchableOpacity
+      style={[
+        {
+          borderRadius: BorderRadius.full,
+          paddingVertical: Spacing[2],
+          paddingHorizontal: Spacing[4],
+          minHeight: 36,
+          justifyContent: 'center',
+          alignItems: 'center',
+          borderWidth: 1,
+        },
+        getBadgeStyles(),
+        disabled && { opacity: 0.6 },
+        style,
+      ]}
+      onPress={() => !disabled && onTabChange(value)}
+      disabled={disabled}
+      accessibilityRole="tab"
+      accessibilityState={{ selected: isActive }}
+      {...rest}
+    >
+      <ThemedText
+        style={[
+          TypographyStyles.label,
+          { color: getTextColor() },
+        ]}
+      >
+        {children}
+      </ThemedText>
+    </TouchableOpacity>
+  );
+}
+
+// TabsContent component
+export function TabsContent({
+  value,
+  children,
+  style,
+  ...rest
+}: TabsContentProps) {
+  const { activeTab } = useTabsContext();
+  
+  if (activeTab !== value) {
+    return null;
+  }
+
+  return (
+    <View
+      style={[
+        {
+          flex: 1,
+          paddingTop: Spacing[4],
+        },
+        style,
+      ]}
+      {...rest}
+    >
+      {children}
+    </View>
+  );
+}

--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -87,7 +87,6 @@ export function TabsList({ children, style, ...rest }: TabsListProps) {
       horizontal
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={{
-        paddingHorizontal: Spacing[4],
         gap: Spacing[2],
         alignItems: 'center',
       }}


### PR DESCRIPTION
## 概要

issue #22 の要件に基づいてshadcn/uiライクなTabコンポーネントを実装しました。

## 変更内容

### 新規追加コンポーネント
- `Tabs` - メインコンテナコンポーネント
- `TabsList` - 横スクロール対応のタブリスト
- `TabsTrigger` - バッジスタイルのタブボタン
- `TabsContent` - タブコンテンツ

### 実装した機能
- ✅ shadcn/uiと同様のAPI設計
- ✅ TypeScript完全サポート
- ✅ 横スクロール機能（TabsList）
- ✅ アクセシビリティ対応（role="tab", accessibilityState）
- ✅ バッジスタイルのデザイン（アクティブ：黒、非アクティブ：グレー）
- ✅ React Native/Expo環境での動作確認済み

### デザイン仕様
- **TabsTrigger**
  - アクティブ状態：黒色のバッジスタイル
  - 非アクティブ状態：グレー色のバッジスタイル
  - 完全な角丸デザイン（BorderRadius.full）
- **TabsList**
  - 横スクロール可能
  - スクロールインジケーターは非表示
  - 適切なパディング・ギャップ設定

## テスト方法

1. `npm run lint` ✅（エラーなし）
2. design-systemページで以下の確認:
   - 基本的なタブ切り替え
   - 横スクロール動作（多数のタブ）
   - カードコンテンツとの組み合わせ

## 影響範囲

- 新規ファイル追加のみ
- 既存コンポーネントへの影響なし
- API変更なし

🤖 Generated with [Claude Code](https://claude.ai/code)