### PR TITLE
feat: textarea コンポーネントの実装

### DIFF
--- a/app/(tabs)/design-system.tsx
+++ b/app/(tabs)/design-system.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, Dialog
 import { List, ListItem, ListItemText, ListItemIcon, ListItemAction, ListLabel } from '@/components/ui/list';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { TextInput } from '@/components/ui/text-input';
+import { Textarea } from '@/components/ui/textarea';
 import { IconSymbol } from '@/components/ui/icon-symbol';
 import { ColorPalette, Shadow, BorderRadius, Spacing } from '@/constants/design-tokens';
 import { useTheme } from '@/hooks/use-theme';
@@ -168,6 +169,9 @@ function ComponentShowcase() {
       </Collapsible>
       <Collapsible title="Text Inputs">
         <TextInputShowcase />
+      </Collapsible>
+      <Collapsible title="Textareas">
+        <TextareaShowcase />
       </Collapsible>
     </ThemedView>
   );
@@ -914,6 +918,101 @@ function TabsShowcase() {
           </Card>
         </TabsContent>
       </Tabs>
+    </ThemedView>
+  );
+}
+
+function TextareaShowcase() {
+  const [baseValue, setBaseValue] = useState('');
+  const [borderlessValue, setBorderlessValue] = useState('');
+  const [errorValue, setErrorValue] = useState('');
+
+  return (
+    <ThemedView style={styles.componentSection}>
+      <ThemedText type="h6">Variants</ThemedText>
+      <View style={{ gap: 16, marginTop: 8 }}>
+        <Textarea
+          placeholder="Base variant textarea"
+          variant="base"
+          value={baseValue}
+          onChangeText={setBaseValue}
+        />
+        <Textarea
+          placeholder="Borderless variant textarea"
+          variant="borderless"
+          value={borderlessValue}
+          onChangeText={setBorderlessValue}
+        />
+      </View>
+
+      <ThemedText type="h6" style={{ marginTop: 16 }}>Sizes</ThemedText>
+      <View style={{ gap: 16, marginTop: 8 }}>
+        <Textarea
+          placeholder="Small textarea"
+          size="small"
+          rows={3}
+        />
+        <Textarea
+          placeholder="Medium textarea (default)"
+          size="medium"
+          rows={4}
+        />
+        <Textarea
+          placeholder="Large textarea"
+          size="large"
+          rows={5}
+        />
+      </View>
+
+      <ThemedText type="h6" style={{ marginTop: 16 }}>With Labels</ThemedText>
+      <View style={{ gap: 16, marginTop: 8 }}>
+        <Textarea
+          label="Description"
+          placeholder="Enter description"
+          rows={3}
+        />
+        <Textarea
+          label="Comments"
+          placeholder="Leave your comments"
+          variant="borderless"
+          rows={4}
+        />
+      </View>
+
+      <ThemedText type="h6" style={{ marginTop: 16 }}>Error State</ThemedText>
+      <View style={{ gap: 16, marginTop: 8 }}>
+        <Textarea
+          label="Feedback"
+          placeholder="Please provide feedback"
+          value={errorValue}
+          onChangeText={setErrorValue}
+          error="This field is required"
+          rows={3}
+        />
+      </View>
+
+      <ThemedText type="h6" style={{ marginTop: 16 }}>Different Row Counts</ThemedText>
+      <View style={{ gap: 16, marginTop: 8 }}>
+        <Textarea
+          placeholder="2 rows"
+          rows={2}
+        />
+        <Textarea
+          placeholder="6 rows"
+          rows={6}
+        />
+        <Textarea
+          placeholder="8 rows"
+          rows={8}
+        />
+      </View>
+
+      <ThemedText type="h6" style={{ marginTop: 16 }}>Full Width</ThemedText>
+      <Textarea
+        placeholder="Full width textarea"
+        fullWidth
+        rows={4}
+      />
     </ThemedView>
   );
 }

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -9,6 +9,7 @@ export { List, ListItem, ListItemText, ListItemIcon, ListItemAction, ListLabel }
 export { Spacing } from './spacing';
 export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';
 export { TextInput } from './text-input';
+export { Textarea } from './textarea';
 
 // Re-export existing components
 export { IconSymbol } from './icon-symbol';

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,159 @@
+import { TextInput as RNTextInput, View, type TextInputProps as RNTextInputProps } from "react-native";
+import { TypographyStyles } from "@/constants/styles";
+import { useTheme } from "@/hooks/use-theme";
+import { ThemedText } from "@/components/themed-text";
+import { ColorPalette, Spacing, BorderRadius } from "@/constants/design-tokens";
+
+export type TextareaVariant = "base" | "borderless";
+export type TextareaSize = "small" | "medium" | "large";
+
+export type TextareaProps = RNTextInputProps & {
+  variant?: TextareaVariant;
+  size?: TextareaSize;
+  label?: string;
+  error?: string;
+  fullWidth?: boolean;
+  rows?: number;
+};
+
+export function Textarea({
+  variant = "base",
+  size = "medium",
+  label,
+  error,
+  fullWidth = false,
+  rows = 4,
+  style,
+  ...rest
+}: TextareaProps) {
+  const { theme } = useTheme();
+
+  const getVariantStyles = () => {
+    switch (variant) {
+      case "base":
+        return {
+          borderWidth: 1,
+          borderColor: error ? ColorPalette.error[500] : theme.border.primary,
+          backgroundColor: theme.background.secondary,
+        };
+      case "borderless":
+        return {
+          borderWidth: 0,
+          backgroundColor: "transparent",
+        };
+      default:
+        return {};
+    }
+  };
+
+  const getSizeStyles = () => {
+    const basePadding = {
+      small: Spacing[3],
+      medium: Spacing[3],
+      large: Spacing[4],
+    }[size];
+
+    const lineHeight = {
+      small: 20,
+      medium: 24,
+      large: 28,
+    }[size];
+
+    const minHeight = lineHeight * rows;
+
+    switch (size) {
+      case "small":
+        return {
+          minHeight,
+          padding: basePadding,
+          fontSize: TypographyStyles.bodySmall.fontSize,
+          lineHeight,
+        };
+      case "large":
+        return {
+          minHeight,
+          padding: basePadding,
+          fontSize: TypographyStyles.bodyLarge.fontSize,
+          lineHeight,
+        };
+      case "medium":
+      default:
+        return {
+          minHeight,
+          padding: basePadding,
+          fontSize: TypographyStyles.body.fontSize,
+          lineHeight,
+        };
+    }
+  };
+
+  const getLabelStyle = () => {
+    switch (size) {
+      case "small":
+        return TypographyStyles.captionMedium;
+      case "large":
+        return TypographyStyles.bodyMedium;
+      case "medium":
+      default:
+        return TypographyStyles.bodySmall;
+    }
+  };
+
+  return (
+    <View style={[fullWidth && { width: "100%" }]}>
+      {label && (
+        <ThemedText
+          style={[
+            getLabelStyle(),
+            {
+              marginBottom: Spacing[2],
+              color: error ? ColorPalette.error[500] : theme.text.secondary,
+            },
+          ]}
+        >
+          {label}
+        </ThemedText>
+      )}
+      <View
+        style={[
+          {
+            borderRadius: BorderRadius.md,
+            ...getVariantStyles(),
+          },
+          fullWidth && { width: "100%" },
+        ]}
+      >
+        <RNTextInput
+          style={[
+            {
+              color: theme.text.primary,
+              fontSize: getSizeStyles().fontSize,
+              lineHeight: getSizeStyles().lineHeight,
+              minHeight: getSizeStyles().minHeight,
+              padding: getSizeStyles().padding,
+              textAlignVertical: "top",
+            },
+            style,
+          ]}
+          placeholderTextColor={theme.text.secondary}
+          multiline={true}
+          numberOfLines={rows}
+          {...rest}
+        />
+      </View>
+      {error && (
+        <ThemedText
+          style={[
+            TypographyStyles.captionMedium,
+            {
+              marginTop: Spacing[1],
+              color: ColorPalette.error[500],
+            },
+          ]}
+        >
+          {error}
+        </ThemedText>
+      )}
+    </View>
+  );
+}


### PR DESCRIPTION
## 概要
- issue #35 の対応として、複数行入力可能な textarea コンポーネントを作成
- 既存の text-input コンポーネントと統一されたスタイルデザインを採用
- design-system ページに showcase を追加

## 実装内容
- **新しいコンポーネント**: `components/ui/textarea.tsx`
  - `base` と `borderless` の2つのvariantをサポート
  - `small`、`medium`、`large` の3つのサイズをサポート
  - ラベル、エラー状態、行数指定が可能
  - text-inputと同様のスタイリングシステムを使用

- **デザインシステム統合**: 
  - `components/ui/index.ts` にTextareaをエクスポート追加
  - `app/(tabs)/design-system.tsx` にTextareaShowcaseを追加

## テスト計画
- [ ] 各variant（base/borderless）の表示確認
- [ ] 各size（small/medium/large）の表示確認  
- [ ] ラベル、エラー状態の表示確認
- [ ] 行数指定の動作確認
- [ ] デザインシステムページでの表示確認

## 影響範囲
- 新規コンポーネントの追加のため、既存機能への影響はなし
- デザインシステムページに新しいセクションが追加

🤖 Generated with [Claude Code](https://claude.ai/code)