### PR TITLE
カレンダーの日付セルのレスポンシブ対応

### DIFF
--- a/features/journal/components/calendar.tsx
+++ b/features/journal/components/calendar.tsx
@@ -3,7 +3,7 @@ import { ThemedText } from "@/components/themed-text";
 import { ThemedView } from "@/components/themed-view";
 import { useTheme } from "@/hooks/use-theme";
 import { Spacing, BorderRadius, Typography, ColorPalette } from "@/constants/design-tokens";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export type CalendarProps = {
   selectedDate?: Date;
@@ -14,10 +14,28 @@ export type CalendarProps = {
 export function Calendar({ selectedDate, onDateSelect, journalDates = [] }: CalendarProps) {
   const { theme } = useTheme();
   const [currentMonth, setCurrentMonth] = useState(new Date());
-  
-  const screenWidth = Dimensions.get('window').width;
-  const calendarWidth = screenWidth - (Spacing[4] * 2);
-  const dayWidth = (calendarWidth - (Spacing[2] * 6)) / 7;
+  const [screenData, setScreenData] = useState(() => {
+    const { width } = Dimensions.get('window');
+    const calendarWidth = width - (Spacing[4] * 2);
+    const dayWidth = (calendarWidth - (Spacing[2] * 6)) / 7;
+    return { screenWidth: width, calendarWidth, dayWidth };
+  });
+
+  useEffect(() => {
+    const subscription = Dimensions.addEventListener('change', ({ window }) => {
+      const calendarWidth = window.width - (Spacing[4] * 2);
+      const dayWidth = (calendarWidth - (Spacing[2] * 6)) / 7;
+      setScreenData({ 
+        screenWidth: window.width, 
+        calendarWidth, 
+        dayWidth 
+      });
+    });
+
+    return () => subscription?.remove();
+  }, []);
+
+  const { dayWidth } = screenData;
 
   const getDaysInMonth = (date: Date) => {
     return new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate();


### PR DESCRIPTION
## 概要
カレンダーコンポーネントの日付セルがウィンドウサイズを超えてしまう問題を修正しました。

## 変更内容
- 固定的な画面サイズ計算を動的な計算に変更
- `useEffect`と`Dimensions.addEventListener`を使用して画面サイズ変更を監視
- ウィンドウサイズに応じて日付セルのサイズが自動調整されるよう改善

## 修正前の問題
- `Dimensions.get('window')`が一度だけ実行され、画面サイズ変更時に更新されない
- 日付セルのサイズが固定で、小さい画面でレイアウト崩れが発生

## 修正後の改善点
- 画面サイズ変更時に自動的にセルサイズが再計算される
- レスポンシブデザインに対応し、様々な画面サイズで適切に表示される
- 既存の機能は維持しつつ、パフォーマンスも考慮した実装

## テスト計画
- [ ] 異なる画面サイズでのカレンダー表示確認
- [ ] 画面回転時の動作確認
- [ ] 既存機能（日付選択、今日の日付表示等）の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)