### PR TITLE
今週表示用のWeeklyCalendarコンポーネントを追加

### DIFF
--- a/features/journal/components/index.ts
+++ b/features/journal/components/index.ts
@@ -1,2 +1,4 @@
 export { Calendar } from './calendar';
 export type { CalendarProps } from './calendar';
+export { WeeklyCalendar } from './weekly-calendar';
+export type { WeeklyCalendarProps } from './weekly-calendar';

--- a/features/journal/components/weekly-calendar.tsx
+++ b/features/journal/components/weekly-calendar.tsx
@@ -1,0 +1,144 @@
+import { View, TouchableOpacity } from "react-native";
+import { ThemedText } from "@/components/themed-text";
+import { ThemedView } from "@/components/themed-view";
+import { useTheme } from "@/hooks/use-theme";
+import { Spacing, BorderRadius, Typography, ColorPalette } from "@/constants/design-tokens";
+
+export type WeeklyCalendarProps = {
+  onDateClick?: (date: Date) => void;
+  journalDates?: Date[];
+};
+
+export function WeeklyCalendar({ onDateClick, journalDates = [] }: WeeklyCalendarProps) {
+  const { theme } = useTheme();
+
+  const getWeekDates = () => {
+    const today = new Date();
+    const startOfWeek = new Date(today);
+    const dayOfWeek = today.getDay();
+    startOfWeek.setDate(today.getDate() - dayOfWeek);
+    
+    const weekDates = [];
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(startOfWeek);
+      date.setDate(startOfWeek.getDate() + i);
+      weekDates.push(date);
+    }
+    return weekDates;
+  };
+
+  const isToday = (date: Date) => {
+    const today = new Date();
+    return date.toDateString() === today.toDateString();
+  };
+
+  const hasJournal = (date: Date) => {
+    return journalDates.some(journalDate => 
+      journalDate.toDateString() === date.toDateString()
+    );
+  };
+
+  const renderDayHeaders = () => (
+    <View style={{
+      flexDirection: 'row',
+      paddingHorizontal: Spacing[2],
+      marginBottom: Spacing[2],
+    }}>
+      {['日', '月', '火', '水', '木', '金', '土'].map((day, index) => (
+        <View
+          key={day}
+          style={{
+            flex: 1,
+            alignItems: 'center',
+          }}
+        >
+          <ThemedText style={{
+            fontSize: Typography.fontSize.sm,
+            fontWeight: Typography.fontWeight.medium,
+            color: index === 0 ? ColorPalette.error[500] : 
+                   index === 6 ? ColorPalette.primary[500] : 
+                   theme.text.secondary,
+          }}>
+            {day}
+          </ThemedText>
+        </View>
+      ))}
+    </View>
+  );
+
+  const renderWeekDays = () => {
+    const weekDates = getWeekDates();
+
+    return (
+      <View
+        style={{
+          flexDirection: 'row',
+          paddingHorizontal: Spacing[2],
+        }}
+      >
+        {weekDates.map((date, index) => {
+          const isTodayDate = isToday(date);
+          const hasJournalEntry = hasJournal(date);
+
+          return (
+            <TouchableOpacity
+              key={date.toDateString()}
+              onPress={() => onDateClick?.(date)}
+              style={{
+                flex: 1,
+                aspectRatio: 0.8,
+                alignItems: 'center',
+                justifyContent: 'center',
+                borderRadius: BorderRadius.base,
+                backgroundColor: 'transparent',
+                position: 'relative',
+                paddingBottom: Spacing[2],
+              }}
+            >
+              <View style={{
+                width: isTodayDate ? 32 : 'auto',
+                height: isTodayDate ? 32 : 'auto',
+                borderRadius: isTodayDate ? BorderRadius.lg : 0,
+                backgroundColor: isTodayDate ? theme.brand.primary : 'transparent',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}>
+                <ThemedText style={{
+                  fontSize: Typography.fontSize.base,
+                  fontWeight: isTodayDate ? Typography.fontWeight.semibold : Typography.fontWeight.normal,
+                  color: isTodayDate ? '#ffffff' : theme.text.primary,
+                }}>
+                  {date.getDate()}
+                </ThemedText>
+              </View>
+              
+              {hasJournalEntry && (
+                <View style={{
+                  position: 'absolute',
+                  bottom: Spacing[1],
+                  width: Spacing[1],
+                  height: Spacing[1],
+                  borderRadius: BorderRadius.full,
+                  backgroundColor: theme.brand.primary,
+                }} />
+              )}
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    );
+  };
+
+  return (
+    <ThemedView style={{
+      borderRadius: BorderRadius.lg,
+      padding: Spacing[4],
+      backgroundColor: theme.background.primary,
+      borderWidth: 1,
+      borderColor: theme.border.primary,
+    }}>
+      {renderDayHeaders()}
+      {renderWeekDays()}
+    </ThemedView>
+  );
+}


### PR DESCRIPTION
## 概要
issue#41 の対応として、今週の日付のみを表示するWeeklyCalendarコンポーネントを追加しました。

## 実装内容
- **WeeklyCalendarコンポーネントの新規作成**: `features/journal/components/weekly-calendar.tsx`
- **今週の7日間表示**: 日曜日から土曜日までの今週の日付を表示
- **既存カレンダーとの統一性**: 既存のCalendarコンポーネントと同じ構造とデザインパターンを採用
- **今日の日付ハイライト**: 今日の日付を丸みを帯びた四角形でハイライト表示
- **ジャーナルエントリー表示**: 日付下部にドットでジャーナルエントリーの有無を表示
- **レスポンシブ対応**: aspectRatio 0.8の縦長セルでドット領域を確保

## テスト計画
- [ ] 今週の日付が正しく表示されることを確認
- [ ] 今日の日付がハイライト表示されることを確認
- [ ] 曜日ヘッダーが正しく表示されることを確認（日曜日赤、土曜日青）
- [ ] ジャーナルエントリーのドット表示が正しく動作することを確認
- [ ] 日付タップ時のonDateClickコールバックが正しく呼ばれることを確認
- [ ] ライト/ダークテーマでの表示確認

## 影響範囲
- 新規コンポーネントの追加のため、既存機能への影響はなし
- `features/journal/components/index.ts`にエクスポートを追加

🤖 Generated with [Claude Code](https://claude.ai/code)