### PR TITLE
feat: ホーム画面の作成 (#43)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,104 +1,220 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import React, { useState } from 'react';
+import { View, StyleSheet, ScrollView } from 'react-native';
 
-import { HelloWave } from '@/components/hello-wave';
-import ParallaxScrollView from '@/components/parallax-scroll-view';
 import { ThemedText } from '@/components/themed-text';
 import { ThemedView } from '@/components/themed-view';
-import { Calendar, WeeklyCalendar } from '@/features/journal';
+import { WeeklyCalendar } from '@/features/journal';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogClose } from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { useTheme } from '@/hooks/use-theme';
+import { Spacing } from '@/constants/design-tokens';
+
+type JournalEntry = {
+  id: string;
+  date: Date;
+  content: string;
+  createdAt: Date;
+};
 
 export default function HomeScreen() {
-  const mockJournalDates = [
-    new Date(), // 今日の日付
-    new Date(2024, 11, 15),
-    new Date(2024, 11, 20),
-    new Date(2024, 11, 25),
-  ];
+  const { theme } = useTheme();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [journalText, setJournalText] = useState('');
+  const [journalEntries, setJournalEntries] = useState<JournalEntry[]>([
+    {
+      id: '1',
+      date: new Date(),
+      content: '今日は天気が良くて、散歩に出かけました。桜がとても綺麗で、気持ちの良い一日でした。',
+      createdAt: new Date(),
+    },
+    {
+      id: '2',
+      date: new Date(2024, 11, 15),
+      content: '新しいプロジェクトが始まりました。チームのメンバーと初めての打ち合わせがあり、これからが楽しみです。',
+      createdAt: new Date(2024, 11, 15),
+    },
+    {
+      id: '3',
+      date: new Date(2024, 11, 20),
+      content: '読書の時間を増やしたいと思います。最近忙しくて本を読む時間が取れていませんでした。',
+      createdAt: new Date(2024, 11, 20),
+    },
+  ]);
+
+  const mockJournalDates = journalEntries.map(entry => entry.date);
 
   const handleDateClick = (date: Date) => {
     console.log('クリックされた日付:', date.toLocaleDateString('ja-JP'));
   };
 
+  const handleCreateJournal = () => {
+    if (journalText.trim()) {
+      const newEntry: JournalEntry = {
+        id: Date.now().toString(),
+        date: new Date(),
+        content: journalText.trim(),
+        createdAt: new Date(),
+      };
+      setJournalEntries(prev => [newEntry, ...prev]);
+      setJournalText('');
+      setIsDialogOpen(false);
+    }
+  };
+
+  const formatDate = (date: Date) => {
+    return date.toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }>
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">今週のカレンダー</ThemedText>
-        <WeeklyCalendar
-          onDateClick={handleDateClick}
-          journalDates={mockJournalDates}
-        />
-      </ThemedView>
-      
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">カレンダー</ThemedText>
-        <Calendar
-          onDateClick={handleDateClick}
-          journalDates={mockJournalDates}
-        />
-      </ThemedView>
-      
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-    </ParallaxScrollView>
+    <View style={[styles.container, { backgroundColor: theme.background.default }]}>
+      <ScrollView 
+        style={styles.scrollView}
+        contentContainerStyle={styles.contentContainer}
+        showsVerticalScrollIndicator={false}
+      >
+        <ThemedView style={styles.section}>
+          <ThemedText type="title" style={styles.sectionTitle}>今週のカレンダー</ThemedText>
+          <WeeklyCalendar
+            onDateClick={handleDateClick}
+            journalDates={mockJournalDates}
+          />
+        </ThemedView>
+        
+        <ThemedView style={styles.section}>
+          <ThemedText type="title" style={styles.sectionTitle}>ジャーナル</ThemedText>
+          {journalEntries.map((entry) => (
+            <Card key={entry.id} variant="elevated" style={styles.journalCard}>
+              <CardContent>
+                <ThemedText 
+                  type="defaultSemiBold" 
+                  style={[styles.journalDate, { color: theme.text.secondary }]}
+                >
+                  {formatDate(entry.date)}
+                </ThemedText>
+                <ThemedText style={styles.journalContent}>
+                  {entry.content}
+                </ThemedText>
+              </CardContent>
+            </Card>
+          ))}
+        </ThemedView>
+      </ScrollView>
+
+      <Button
+        icon="plus"
+        iconOnly
+        variant="primary"
+        size="large"
+        style={[styles.fab, { backgroundColor: theme.brand.primary }]}
+        onPress={() => setIsDialogOpen(true)}
+      />
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen} variant="slide">
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>新しいジャーナルを作成</DialogTitle>
+            <DialogClose />
+          </DialogHeader>
+          
+          <View style={styles.dialogContent}>
+            <Textarea
+              variant="borderless"
+              placeholder="今日はどんな一日でしたか？"
+              value={journalText}
+              onChangeText={setJournalText}
+              rows={8}
+              fullWidth
+              style={styles.textArea}
+            />
+            
+            <View style={styles.characterCount}>
+              <ThemedText 
+                style={[styles.characterCountText, { color: theme.text.secondary }]}
+              >
+                {journalText.length} 文字
+              </ThemedText>
+            </View>
+            
+            <Button
+              title="作成"
+              variant="primary"
+              fullWidth
+              onPress={handleCreateJournal}
+              disabled={!journalText.trim()}
+              style={styles.createButton}
+            />
+          </View>
+        </DialogContent>
+      </Dialog>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
+  container: {
+    flex: 1,
   },
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
+  scrollView: {
+    flex: 1,
   },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
+  contentContainer: {
+    paddingHorizontal: Spacing[4],
+    paddingTop: Spacing[4],
+    paddingBottom: 100, // FABのスペースを確保
+  },
+  section: {
+    marginBottom: Spacing[6],
+  },
+  sectionTitle: {
+    marginBottom: Spacing[4],
+  },
+  journalCard: {
+    marginBottom: Spacing[3],
+  },
+  journalDate: {
+    marginBottom: Spacing[2],
+  },
+  journalContent: {
+    lineHeight: 22,
+  },
+  fab: {
     position: 'absolute',
+    right: Spacing[4],
+    bottom: Spacing[6],
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    elevation: 8,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 4,
+    },
+    shadowOpacity: 0.3,
+    shadowRadius: 4.65,
+  },
+  dialogContent: {
+    flex: 1,
+    paddingTop: Spacing[4],
+  },
+  textArea: {
+    flex: 1,
+    marginBottom: Spacing[4],
+  },
+  characterCount: {
+    alignItems: 'flex-end',
+    marginBottom: Spacing[4],
+  },
+  characterCountText: {
+    fontSize: 14,
+  },
+  createButton: {
+    marginTop: 'auto',
   },
 });


### PR DESCRIPTION
## 概要
issue #43 の要件に従い、ホーム画面を実装しました。WeeklyCalendarの配置、ジャーナル一覧表示、ジャーナル作成機能を含む完全なホーム画面を作成しました。

## 実装内容
- **WeeklyCalendar配置**: 今週のカレンダーを画面上部に表示
- **ジャーナル一覧表示**: Cardコンポーネントを使用した見やすいリスト表示
- **FAB（Floating Action Button）**: 画面右下にPlusアイコンの絶対位置ボタン
- **ジャーナル作成Dialog**: slideアニメーション付きの全画面モーダル
- **入力フォーム**: ボーダーレスTextAreaでテキスト入力
- **文字数カウンター**: リアルタイムでの入力文字数表示
- **作成ボタン**: 入力内容の検証と新規ジャーナル追加

## 技術詳細
- **State管理**: React hooksを使用したローカル状態管理
- **レスポンシブデザイン**: デザイントークンを活用した一貫したスタイル
- **ユーザビリティ**: FABの影効果、スムーズなアニメーション
- **型安全性**: TypeScriptによる厳密な型定義

## テスト計画
- [ ] WeeklyCalendarの表示確認
- [ ] ジャーナル一覧の表示確認
- [ ] FABタップでDialogが開くことを確認
- [ ] Dialog内でのテキスト入力確認
- [ ] 文字数カウンターの動作確認
- [ ] 作成ボタンでジャーナルが追加されることを確認
- [ ] Dialogが正しく閉じることを確認
- [ ] ライト/ダークテーマでの表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)