### PR TITLE
ジャーナル作成ダイアログに画像追加機能を追加

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { View, StyleSheet, ScrollView, KeyboardAvoidingView, Platform, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
@@ -33,6 +33,7 @@ export default function HomeScreen() {
   const [selectedImages, setSelectedImages] = useState<string[]>([]);
   const [selectedAI, setSelectedAI] = useState<string>('');
   const [isKeyboardVisible, setIsKeyboardVisible] = useState(false);
+  const scrollViewRef = useRef<ScrollView>(null);
   const [journalEntries, setJournalEntries] = useState<JournalEntry[]>([
     {
       id: '1',
@@ -117,6 +118,14 @@ export default function HomeScreen() {
 
   const handleRemoveImage = (index: number) => {
     setSelectedImages(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const handleInputFocus = () => {
+    setIsKeyboardVisible(true);
+    // ScrollViewを少し下にスクロールして、入力フィールドをキーボードの上に表示
+    setTimeout(() => {
+      scrollViewRef.current?.scrollToEnd({ animated: true });
+    }, 100);
   };
 
   const handleCreateJournal = () => {
@@ -225,12 +234,20 @@ export default function HomeScreen() {
           <KeyboardAvoidingView 
             style={styles.dialogContent}
             behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+            keyboardVerticalOffset={Platform.OS === 'ios' ? 100 : 0}
+            enabled={true}
           >
             <ScrollView 
+              ref={scrollViewRef}
               style={styles.dialogScrollView}
-              contentContainerStyle={{ paddingHorizontal: Spacing[6] }}
+              contentContainerStyle={{ 
+                paddingHorizontal: Spacing[6],
+                flexGrow: 1,
+                paddingBottom: Spacing[4]
+              }}
               showsVerticalScrollIndicator={false}
               keyboardShouldPersistTaps="handled"
+              bounces={false}
             >
               <ImageGrid
                 images={selectedImages}
@@ -246,7 +263,7 @@ export default function HomeScreen() {
                 rows={1}
                 fullWidth
                 style={styles.titleInput}
-                onFocus={() => setIsKeyboardVisible(true)}
+                onFocus={handleInputFocus}
                 onBlur={() => setIsKeyboardVisible(false)}
               />
               
@@ -258,7 +275,7 @@ export default function HomeScreen() {
                 rows={6}
                 fullWidth
                 style={styles.contentInput}
-                onFocus={() => setIsKeyboardVisible(true)}
+                onFocus={handleInputFocus}
                 onBlur={() => setIsKeyboardVisible(false)}
               />
               
@@ -357,6 +374,7 @@ const styles = StyleSheet.create({
   dialogContent: {
     flex: 1,
     paddingTop: Spacing[4],
+    justifyContent: 'space-between',
   },
   dialogScrollView: {
     flex: 1,

--- a/components/ui/image-grid.tsx
+++ b/components/ui/image-grid.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { View, StyleSheet, TouchableOpacity, Dimensions } from 'react-native';
+import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/hooks/use-theme';
+import { Spacing, BorderRadius } from '@/constants/design-tokens';
+
+type ImageGridProps = {
+  images: string[];
+  onRemoveImage: (index: number) => void;
+  maxImages?: number;
+  readonly?: boolean;
+};
+
+export function ImageGrid({ images, onRemoveImage, maxImages = 4, readonly = false }: ImageGridProps) {
+  const { theme } = useTheme();
+  const screenWidth = Dimensions.get('window').width;
+  const containerPadding = Spacing[6] * 2; // Dialog padding
+  const imageGap = Spacing[2];
+  const imagesPerRow = 2;
+  const imageSize = (screenWidth - containerPadding - imageGap) / imagesPerRow;
+
+  if (images.length === 0) {
+    return null;
+  }
+
+  const renderImage = (uri: string, index: number) => (
+    <View key={index} style={[styles.imageContainer, { width: imageSize, height: imageSize }]}>
+      <Image
+        source={{ uri }}
+        style={styles.image}
+        contentFit="cover"
+      />
+      {!readonly && (
+        <TouchableOpacity
+          style={[
+            styles.removeButton,
+            { backgroundColor: theme.semantic.critical }
+          ]}
+          onPress={() => onRemoveImage(index)}
+        >
+          <Ionicons
+            name="close"
+            size={16}
+            color={theme.text.onColor}
+          />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <View style={[styles.grid, { gap: imageGap }]}>
+        {images.map((uri, index) => renderImage(uri, index))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: Spacing[4],
+  },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  imageContainer: {
+    position: 'relative',
+    borderRadius: BorderRadius.md,
+    overflow: 'hidden',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  removeButton: {
+    position: 'absolute',
+    top: 4,
+    right: 4,
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -5,6 +5,8 @@
 export { Button } from './button';
 export { Card } from './card';
 export { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from './dialog';
+export { ImageGrid } from './image-grid';
+export { KeyboardToolbar } from './keyboard-toolbar';
 export { List, ListItem, ListItemText, ListItemIcon, ListItemAction, ListLabel } from './list';
 export { Spacing } from './spacing';
 export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';

--- a/components/ui/keyboard-toolbar.tsx
+++ b/components/ui/keyboard-toolbar.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/hooks/use-theme';
+import { Spacing } from '@/constants/design-tokens';
+
+type KeyboardToolbarProps = {
+  onImagePress: () => void;
+  onBoldPress?: () => void;
+  onItalicPress?: () => void;
+  disabled?: boolean;
+};
+
+export function KeyboardToolbar({ 
+  onImagePress, 
+  onBoldPress, 
+  onItalicPress, 
+  disabled = false 
+}: KeyboardToolbarProps) {
+  const { theme } = useTheme();
+
+  return (
+    <View style={[
+      styles.container, 
+      { 
+        backgroundColor: theme.background.elevated,
+        borderTopColor: theme.border.subtle,
+      }
+    ]}>
+      <TouchableOpacity
+        style={[
+          styles.toolButton,
+          { backgroundColor: theme.background.default }
+        ]}
+        onPress={onImagePress}
+        disabled={disabled}
+      >
+        <Ionicons
+          name="image-outline"
+          size={20}
+          color={disabled ? theme.text.disabled : theme.text.primary}
+        />
+      </TouchableOpacity>
+      
+      {onBoldPress && (
+        <TouchableOpacity
+          style={[
+            styles.toolButton,
+            { backgroundColor: theme.background.default }
+          ]}
+          onPress={onBoldPress}
+          disabled={disabled}
+        >
+          <Ionicons
+            name="text-outline"
+            size={20}
+            color={disabled ? theme.text.disabled : theme.text.primary}
+          />
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    paddingHorizontal: Spacing[4],
+    paddingVertical: Spacing[2],
+    borderTopWidth: 1,
+    gap: Spacing[2],
+    minHeight: 44,
+    alignItems: 'center',
+  },
+  toolButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/models/journal-entry.ts
+++ b/models/journal-entry.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const JournalEntrySchema = z.object({
+  id: z.number().int().positive(),
+  title: z.string().min(1, 'Title is required'),
+  content: z.string().min(1, 'Content is required'),
+  images: z.array(z.string()).max(4, 'Maximum 4 images allowed').optional(),
+  ai_feedback_type: z.string().optional(),
+  date: z.string().datetime(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  synced: z.boolean(),
+  last_modified: z.string().datetime(),
+});
+
+export const CreateJournalEntrySchema = z.object({
+  title: z.string().min(1, 'Title is required'),
+  content: z.string().min(1, 'Content is required'),
+  images: z.array(z.string()).max(4, 'Maximum 4 images allowed').optional(),
+  ai_feedback_type: z.string().optional(),
+  date: z.string().datetime(),
+});
+
+export const UpdateJournalEntrySchema = z.object({
+  title: z.string().min(1, 'Title is required').optional(),
+  content: z.string().min(1, 'Content is required').optional(),
+  images: z.array(z.string()).max(4, 'Maximum 4 images allowed').optional(),
+  ai_feedback_type: z.string().optional(),
+  date: z.string().datetime().optional(),
+});
+
+export type JournalEntry = z.infer<typeof JournalEntrySchema>;
+export type CreateJournalEntryData = z.infer<typeof CreateJournalEntrySchema>;
+export type UpdateJournalEntryData = z.infer<typeof UpdateJournalEntrySchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-font": "~13.3.1",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.3.0",
+        "expo-image-picker": "^16.1.4",
         "expo-linking": "~7.1.5",
         "expo-router": "~5.1.0",
         "expo-splash-screen": "~0.30.9",
@@ -6346,6 +6347,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-font": "~13.3.1",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.3.0",
+    "expo-image-picker": "^16.1.4",
     "expo-linking": "~7.1.5",
     "expo-router": "~5.1.0",
     "expo-splash-screen": "~0.30.9",


### PR DESCRIPTION
## 概要
issue #48 に対応してジャーナル作成ダイアログに画像添付機能を実装しました。

## 実装内容
- **キーボード重複問題の解決**: TextInput/TextAreaにフォーカスが当たった際にキーボードに隠れる問題を修正
- **キーボードツールバー**: キーボード表示時に画像添付アイコンを表示
- **画像添付機能**: expo-image-pickerを使用した画像選択機能（最大4枚）
- **画像表示**: タイトル上部に選択した画像をグリッド表示
- **画像削除**: 編集時に画像を個別に削除可能
- **データモデル拡張**: ジャーナルエントリーモデルに画像フィールドを追加
- **表示対応**: ジャーナルカードでの画像表示対応

## テスト計画
- [ ] ジャーナル作成ダイアログを開く
- [ ] TextInput/TextAreaにフォーカスを当ててキーボードツールバーが表示されることを確認
- [ ] 画像添付アイコンをタップして画像選択が動作することを確認
- [ ] 画像を選択して上部に表示されることを確認
- [ ] 最大4枚まで画像を追加できることを確認
- [ ] 画像削除機能が動作することを確認
- [ ] ジャーナル作成後に画像が保存・表示されることを確認
- [ ] 既存のジャーナルエントリーが正常に表示されることを確認

## 影響範囲
- 新規コンポーネント追加（KeyboardToolbar, ImageGrid）
- ジャーナルエントリーの型定義拡張
- 依存関係追加（expo-image-picker）
- 既存のジャーナル表示機能への影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)