### PR TITLE
ジャーナルに画像投稿機能を追加

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { View, StyleSheet, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, StyleSheet, ScrollView, KeyboardAvoidingView, Platform, Alert } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import * as ImagePicker from 'expo-image-picker';
 
 import { ThemedText } from '@/components/themed-text';
 import { WeeklyCalendar } from '@/features/journal';
@@ -8,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/componen
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
+import { ImagePreview } from '@/components/ui/image-preview';
 import { FBSelectionCard, type AIFeedbackOption } from '@/features/ai-feedback';
 import { useTheme } from '@/hooks/use-theme';
 import { Spacing } from '@/constants/design-tokens';
@@ -16,6 +18,7 @@ type JournalEntry = {
   id: string;
   title: string;
   content: string;
+  images?: string[];
   date: Date;
   createdAt: Date;
 };
@@ -27,6 +30,7 @@ export default function HomeScreen() {
   const [journalTitle, setJournalTitle] = useState('');
   const [journalContent, setJournalContent] = useState('');
   const [selectedAI, setSelectedAI] = useState<string>('');
+  const [selectedImages, setSelectedImages] = useState<string[]>([]);
   const [journalEntries, setJournalEntries] = useState<JournalEntry[]>([
     {
       id: '1',
@@ -84,18 +88,49 @@ export default function HomeScreen() {
     console.log('クリックされた日付:', date.toLocaleDateString('ja-JP'));
   };
 
+  const handleImagePick = async () => {
+    if (selectedImages.length >= 4) {
+      Alert.alert('最大枚数に達しました', '画像は最大4枚まで添付できます。');
+      return;
+    }
+
+    const permissionResult = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    
+    if (permissionResult.granted === false) {
+      Alert.alert('権限が必要です', '画像を選択するには写真ライブラリへのアクセス権限が必要です。');
+      return;
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 0.8,
+    });
+
+    if (!result.canceled && result.assets[0]) {
+      setSelectedImages(prev => [...prev, result.assets[0].uri]);
+    }
+  };
+
+  const handleRemoveImage = (index: number) => {
+    setSelectedImages(prev => prev.filter((_, i) => i !== index));
+  };
+
   const handleCreateJournal = () => {
     if (journalTitle.trim() && journalContent.trim()) {
       const newEntry: JournalEntry = {
         id: Date.now().toString(),
         title: journalTitle.trim(),
         content: journalContent.trim(),
+        images: selectedImages.length > 0 ? selectedImages : undefined,
         date: new Date(),
         createdAt: new Date(),
       };
       setJournalEntries(prev => [newEntry, ...prev]);
       setJournalTitle('');
       setJournalContent('');
+      setSelectedImages([]);
       setSelectedAI('');
       setIsDialogOpen(false);
     }
@@ -137,6 +172,9 @@ export default function HomeScreen() {
                 <CardTitle>{entry.title}</CardTitle>
               </CardHeader>
               <CardContent style={styles.journalCardContent}>
+                {entry.images && entry.images.length > 0 && (
+                  <ImagePreview images={entry.images} />
+                )}
                 <ThemedText style={styles.journalContent}>
                   {entry.content}
                 </ThemedText>
@@ -182,6 +220,12 @@ export default function HomeScreen() {
             behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
           >
             <View style={{ paddingHorizontal: Spacing[6] }}>
+              <ImagePreview
+                images={selectedImages}
+                onRemoveImage={handleRemoveImage}
+                editable={true}
+              />
+              
               <Textarea
                 variant="borderless"
                 placeholder="タイトルを入力してください"
@@ -208,6 +252,17 @@ export default function HomeScreen() {
                 >
                   {journalContent.length} 文字
                 </ThemedText>
+              </View>
+              
+              <View style={styles.imageButtonContainer}>
+                <Button
+                  title="画像を追加"
+                  variant="secondary"
+                  onPress={handleImagePick}
+                  disabled={selectedImages.length >= 4}
+                  icon="image"
+                  style={styles.imageButton}
+                />
               </View>
               
               <FBSelectionCard
@@ -312,5 +367,11 @@ const styles = StyleSheet.create({
   },
   createButton: {
     marginTop: Spacing[4],
+  },
+  imageButtonContainer: {
+    marginBottom: Spacing[4],
+  },
+  imageButton: {
+    alignSelf: 'flex-start',
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -260,7 +260,7 @@ export default function HomeScreen() {
                   variant="secondary"
                   onPress={handleImagePick}
                   disabled={selectedImages.length >= 4}
-                  icon="image"
+                  icon="photo"
                   style={styles.imageButton}
                 />
               </View>

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -22,6 +22,8 @@ const MAPPING = {
   "paperplane.fill": "send",
   "chevron.left.forwardslash.chevron.right": "code",
   "chevron.right": "chevron-right",
+  "photo": "image",
+  "plus": "add",
 } as IconMapping;
 
 /**

--- a/components/ui/image-preview.tsx
+++ b/components/ui/image-preview.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
+import { useTheme } from '@/hooks/use-theme';
+import { Spacing, BorderRadius } from '@/constants/design-tokens';
+
+type ImagePreviewProps = {
+  images: string[];
+  onRemoveImage?: (index: number) => void;
+  editable?: boolean;
+};
+
+export function ImagePreview({ images, onRemoveImage, editable = false }: ImagePreviewProps) {
+  const { theme } = useTheme();
+
+  if (images.length === 0) {
+    return null;
+  }
+
+  return (
+    <View style={styles.container}>
+      {images.map((uri, index) => (
+        <View key={index} style={styles.imageContainer}>
+          <Image
+            source={{ uri }}
+            style={styles.image}
+            contentFit="cover"
+          />
+          {editable && onRemoveImage && (
+            <TouchableOpacity
+              style={[
+                styles.removeButton,
+                { backgroundColor: theme.semantic.critical }
+              ]}
+              onPress={() => onRemoveImage(index)}
+            >
+              <Ionicons
+                name="close"
+                size={16}
+                color={theme.text.onColor}
+              />
+            </TouchableOpacity>
+          )}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing[2],
+    marginBottom: Spacing[4],
+  },
+  imageContainer: {
+    position: 'relative',
+    width: 80,
+    height: 80,
+    borderRadius: BorderRadius.md,
+    overflow: 'hidden',
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  removeButton: {
+    position: 'absolute',
+    top: 4,
+    right: 4,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/components/ui/image-preview.tsx
+++ b/components/ui/image-preview.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
-import { Spacing, BorderRadius } from '@/constants/design-tokens';
+import { Spacing, BorderRadius, ColorPalette } from '@/constants/design-tokens';
 
 type ImagePreviewProps = {
   images: string[];
@@ -29,14 +29,14 @@ export function ImagePreview({ images, onRemoveImage, editable = false }: ImageP
             <TouchableOpacity
               style={[
                 styles.removeButton,
-                { backgroundColor: '#ef4444' } // red-500
+                { backgroundColor: ColorPalette.error[500] }
               ]}
               onPress={() => onRemoveImage(index)}
             >
               <Ionicons
                 name="close"
                 size={16}
-                color="#ffffff"
+                color={ColorPalette.neutral[50]}
               />
             </TouchableOpacity>
           )}

--- a/components/ui/image-preview.tsx
+++ b/components/ui/image-preview.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
-import { useTheme } from '@/hooks/use-theme';
 import { Spacing, BorderRadius } from '@/constants/design-tokens';
 
 type ImagePreviewProps = {
@@ -12,7 +11,6 @@ type ImagePreviewProps = {
 };
 
 export function ImagePreview({ images, onRemoveImage, editable = false }: ImagePreviewProps) {
-  const { theme } = useTheme();
 
   if (images.length === 0) {
     return null;
@@ -31,14 +29,14 @@ export function ImagePreview({ images, onRemoveImage, editable = false }: ImageP
             <TouchableOpacity
               style={[
                 styles.removeButton,
-                { backgroundColor: theme.semantic.critical }
+                { backgroundColor: '#ef4444' } // red-500
               ]}
               onPress={() => onRemoveImage(index)}
             >
               <Ionicons
                 name="close"
                 size={16}
-                color={theme.text.onColor}
+                color="#ffffff"
               />
             </TouchableOpacity>
           )}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -5,6 +5,7 @@
 export { Button } from './button';
 export { Card } from './card';
 export { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from './dialog';
+export { ImagePreview } from './image-preview';
 export { List, ListItem, ListItemText, ListItemIcon, ListItemAction, ListLabel } from './list';
 export { Spacing } from './spacing';
 export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-font": "~13.3.1",
         "expo-haptics": "~14.1.4",
         "expo-image": "~2.3.0",
+        "expo-image-picker": "^16.1.4",
         "expo-linking": "~7.1.5",
         "expo-router": "~5.1.0",
         "expo-splash-screen": "~0.30.9",
@@ -6346,6 +6347,27 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-font": "~13.3.1",
     "expo-haptics": "~14.1.4",
     "expo-image": "~2.3.0",
+    "expo-image-picker": "^16.1.4",
     "expo-linking": "~7.1.5",
     "expo-router": "~5.1.0",
     "expo-splash-screen": "~0.30.9",


### PR DESCRIPTION
## 概要
ジャーナル作成機能に画像投稿機能を追加しました。

## 実装内容
- **画像選択機能**: expo-image-pickerを使用した画像ライブラリからの選択
- **画像プレビュー**: 選択した画像をリアルタイムでプレビュー表示
- **画像管理**: 最大4枚まで画像を追加可能、個別削除機能
- **ジャーナル表示**: 作成したジャーナルに画像を表示
- **シンプルなUI**: 既存のデザインシステムに統合

## 機能詳細
- 画像は最大4枚まで追加可能
- 正方形（1:1）のアスペクト比で画像を編集
- 画像品質は0.8に設定（ファイルサイズ最適化）
- 編集時に画像の個別削除が可能
- 権限チェックとエラーハンドリング

## テスト計画
- [ ] ジャーナル作成ダイアログを開く
- [ ] 「画像を追加」ボタンをタップ
- [ ] 画像ライブラリから画像を選択
- [ ] 選択した画像がプレビューに表示されることを確認
- [ ] 複数の画像を追加（最大4枚）
- [ ] 画像削除機能が動作することを確認
- [ ] ジャーナル作成後に画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)