### PR TITLE
画像を拡大表示するコンポーネントを追加

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { ColorPalette } from "@/constants/design-tokens";
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import type { SymbolName } from "@/components/ui/icon-symbol";
 
-export type ButtonVariant = "primary" | "secondary" | "outline" | "ghost";
+export type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "modal";
 export type ButtonSize = "small" | "medium" | "large";
 
 export type ButtonProps = TouchableOpacityProps & {
@@ -60,6 +60,11 @@ export function Button({
       case "ghost":
         return {
           backgroundColor: "transparent",
+        };
+      case "modal":
+        return {
+          backgroundColor: "rgba(0, 0, 0, 0.5)",
+          borderRadius: 22,
         };
       default:
         return {};
@@ -119,6 +124,8 @@ export function Button({
         return theme.brand.primary;
       case "ghost":
         return theme.brand.primary;
+      case "modal":
+        return ColorPalette.neutral[50];
       default:
         return theme.text.primary;
     }

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { ColorPalette } from "@/constants/design-tokens";
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import type { SymbolName } from "@/components/ui/icon-symbol";
 
-export type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "modal";
+export type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "overlay";
 export type ButtonSize = "small" | "medium" | "large";
 
 export type ButtonProps = TouchableOpacityProps & {
@@ -61,7 +61,7 @@ export function Button({
         return {
           backgroundColor: "transparent",
         };
-      case "modal":
+      case "overlay":
         return {
           backgroundColor: "rgba(0, 0, 0, 0.5)",
           borderRadius: 22,
@@ -124,7 +124,7 @@ export function Button({
         return theme.brand.primary;
       case "ghost":
         return theme.brand.primary;
-      case "modal":
+      case "overlay":
         return ColorPalette.neutral[50];
       default:
         return theme.text.primary;

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -6,8 +6,8 @@ import { ColorPalette } from "@/constants/design-tokens";
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import type { SymbolName } from "@/components/ui/icon-symbol";
 
-export type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "overlay";
-export type ButtonSize = "small" | "medium" | "large";
+export type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "overlay" | "remove";
+export type ButtonSize = "xs" | "small" | "medium" | "large";
 
 export type ButtonProps = TouchableOpacityProps & {
   title?: string;
@@ -66,6 +66,11 @@ export function Button({
           backgroundColor: "rgba(0, 0, 0, 0.5)",
           borderRadius: 22,
         };
+      case "remove":
+        return {
+          backgroundColor: ColorPalette.error[500],
+          borderRadius: 10,
+        };
       default:
         return {};
     }
@@ -74,6 +79,8 @@ export function Button({
   const getSizeStyles = () => {
     const baseStyle = (() => {
       switch (size) {
+        case "xs":
+          return ComponentStyles.buttonXs;
         case "small":
           return ComponentStyles.buttonSmall;
         case "large":
@@ -126,6 +133,8 @@ export function Button({
         return theme.brand.primary;
       case "overlay":
         return ColorPalette.neutral[50];
+      case "remove":
+        return ColorPalette.neutral[50];
       default:
         return theme.text.primary;
     }
@@ -133,6 +142,8 @@ export function Button({
 
   const getTextStyle = () => {
     switch (size) {
+      case "xs":
+        return TypographyStyles.buttonXs;
       case "small":
         return TypographyStyles.buttonSmall;
       case "large":
@@ -145,6 +156,8 @@ export function Button({
 
   const getIconSize = () => {
     switch (size) {
+      case "xs":
+        return 12;
       case "small":
         return 16;
       case "large":

--- a/components/ui/image-modal.tsx
+++ b/components/ui/image-modal.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  Modal,
+  StyleSheet,
+  TouchableOpacity,
+  Dimensions,
+  SafeAreaView,
+} from 'react-native';
+import { Image } from 'expo-image';
+import { Ionicons } from '@expo/vector-icons';
+import { ColorPalette } from '@/constants/design-tokens';
+
+type ImageModalProps = {
+  visible: boolean;
+  imageUri: string;
+  onClose: () => void;
+};
+
+const { width: screenWidth, height: screenHeight } = Dimensions.get('window');
+
+export function ImageModal({ visible, imageUri, onClose }: ImageModalProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <SafeAreaView style={styles.overlay}>
+        <TouchableOpacity style={styles.closeButton} onPress={onClose}>
+          <Ionicons
+            name="close"
+            size={28}
+            color={ColorPalette.neutral[50]}
+          />
+        </TouchableOpacity>
+        
+        <TouchableOpacity
+          style={styles.imageContainer}
+          activeOpacity={1}
+          onPress={onClose}
+        >
+          <Image
+            source={{ uri: imageUri }}
+            style={styles.image}
+            contentFit="contain"
+          />
+        </TouchableOpacity>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.9)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 50,
+    right: 20,
+    zIndex: 1,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  imageContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: screenWidth,
+    height: screenHeight,
+  },
+  image: {
+    width: screenWidth * 0.9,
+    height: screenHeight * 0.8,
+  },
+});

--- a/components/ui/image-modal.tsx
+++ b/components/ui/image-modal.tsx
@@ -7,8 +7,7 @@ import {
   SafeAreaView,
 } from 'react-native';
 import { Image } from 'expo-image';
-import { Ionicons } from '@expo/vector-icons';
-import { ColorPalette } from '@/constants/design-tokens';
+import { Button } from '@/components/ui/button';
 
 type ImageModalProps = {
   visible: boolean;
@@ -27,13 +26,14 @@ export function ImageModal({ visible, imageUri, onClose }: ImageModalProps) {
       onRequestClose={onClose}
     >
       <SafeAreaView style={styles.overlay}>
-        <TouchableOpacity style={styles.closeButton} onPress={onClose}>
-          <Ionicons
-            name="close"
-            size={28}
-            color={ColorPalette.neutral[50]}
-          />
-        </TouchableOpacity>
+        <Button
+          variant="modal"
+          size="large"
+          iconOnly
+          icon="xmark"
+          onPress={onClose}
+          style={styles.closeButton}
+        />
         
         <TouchableOpacity
           style={styles.imageContainer}
@@ -65,10 +65,6 @@ const styles = StyleSheet.create({
     zIndex: 1,
     width: 44,
     height: 44,
-    borderRadius: 22,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
   },
   imageContainer: {
     flex: 1,

--- a/components/ui/image-modal.tsx
+++ b/components/ui/image-modal.tsx
@@ -27,7 +27,7 @@ export function ImageModal({ visible, imageUri, onClose }: ImageModalProps) {
     >
       <SafeAreaView style={styles.overlay}>
         <Button
-          variant="modal"
+          variant="overlay"
           size="large"
           iconOnly
           icon="xmark"

--- a/components/ui/image-preview.tsx
+++ b/components/ui/image-preview.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { Image } from 'expo-image';
-import { Ionicons } from '@expo/vector-icons';
-import { Spacing, BorderRadius, ColorPalette } from '@/constants/design-tokens';
+import { Spacing, BorderRadius } from '@/constants/design-tokens';
+import { Button } from './button';
 import { ImageModal } from './image-modal';
 
 type ImagePreviewProps = {
@@ -40,19 +40,14 @@ export function ImagePreview({ images, onRemoveImage, editable = false, onImageP
               />
             </TouchableOpacity>
             {editable && onRemoveImage && (
-              <TouchableOpacity
-                style={[
-                  styles.removeButton,
-                  { backgroundColor: ColorPalette.error[500] }
-                ]}
+              <Button
+                variant="remove"
+                size="xs"
+                iconOnly
+                icon="xmark"
                 onPress={() => onRemoveImage(index)}
-              >
-                <Ionicons
-                  name="close"
-                  size={16}
-                  color={ColorPalette.neutral[50]}
-                />
-              </TouchableOpacity>
+                style={styles.removeButton}
+              />
             )}
           </View>
         ))}
@@ -93,8 +88,5 @@ const styles = StyleSheet.create({
     right: 4,
     width: 20,
     height: 20,
-    borderRadius: 10,
-    justifyContent: 'center',
-    alignItems: 'center',
   },
 });

--- a/components/ui/image-preview.tsx
+++ b/components/ui/image-preview.tsx
@@ -1,48 +1,71 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { Image } from 'expo-image';
 import { Ionicons } from '@expo/vector-icons';
 import { Spacing, BorderRadius, ColorPalette } from '@/constants/design-tokens';
+import { ImageModal } from './image-modal';
 
 type ImagePreviewProps = {
   images: string[];
   onRemoveImage?: (index: number) => void;
   editable?: boolean;
+  onImagePress?: (imageUri: string) => void;
 };
 
-export function ImagePreview({ images, onRemoveImage, editable = false }: ImagePreviewProps) {
+export function ImagePreview({ images, onRemoveImage, editable = false, onImagePress }: ImagePreviewProps) {
+  const [selectedImageUri, setSelectedImageUri] = useState<string | null>(null);
 
   if (images.length === 0) {
     return null;
   }
 
+  const handleImagePress = (uri: string) => {
+    if (onImagePress) {
+      onImagePress(uri);
+    } else {
+      setSelectedImageUri(uri);
+    }
+  };
+
   return (
-    <View style={styles.container}>
-      {images.map((uri, index) => (
-        <View key={index} style={styles.imageContainer}>
-          <Image
-            source={{ uri }}
-            style={styles.image}
-            contentFit="cover"
-          />
-          {editable && onRemoveImage && (
-            <TouchableOpacity
-              style={[
-                styles.removeButton,
-                { backgroundColor: ColorPalette.error[500] }
-              ]}
-              onPress={() => onRemoveImage(index)}
-            >
-              <Ionicons
-                name="close"
-                size={16}
-                color={ColorPalette.neutral[50]}
+    <>
+      <View style={styles.container}>
+        {images.map((uri, index) => (
+          <View key={index} style={styles.imageContainer}>
+            <TouchableOpacity onPress={() => handleImagePress(uri)}>
+              <Image
+                source={{ uri }}
+                style={styles.image}
+                contentFit="cover"
               />
             </TouchableOpacity>
-          )}
-        </View>
-      ))}
-    </View>
+            {editable && onRemoveImage && (
+              <TouchableOpacity
+                style={[
+                  styles.removeButton,
+                  { backgroundColor: ColorPalette.error[500] }
+                ]}
+                onPress={() => onRemoveImage(index)}
+              >
+                <Ionicons
+                  name="close"
+                  size={16}
+                  color={ColorPalette.neutral[50]}
+                />
+              </TouchableOpacity>
+            )}
+          </View>
+        ))}
+      </View>
+      
+      {selectedImageUri && (
+        <ImageModal
+          visible={!!selectedImageUri}
+          imageUri={selectedImageUri}
+          onClose={() => setSelectedImageUri(null)}
+        />
+      )}
+    </>
   );
 }
 

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -6,6 +6,7 @@ export { Button } from './button';
 export { Card } from './card';
 export { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from './dialog';
 export { ImagePreview } from './image-preview';
+export { ImageModal } from './image-modal';
 export { List, ListItem, ListItemText, ListItemIcon, ListItemAction, ListLabel } from './list';
 export { Spacing } from './spacing';
 export { Tabs, TabsList, TabsTrigger, TabsContent } from './tabs';

--- a/constants/styles.ts
+++ b/constants/styles.ts
@@ -92,6 +92,12 @@ export const TypographyStyles = StyleSheet.create({
     lineHeight: Typography.fontSize.sm * Typography.lineHeight.none,
     textAlign: 'center' as const,
   },
+  buttonXs: {
+    fontSize: Typography.fontSize.xs,
+    fontWeight: Typography.fontWeight.medium,
+    lineHeight: Typography.fontSize.xs * Typography.lineHeight.none,
+    textAlign: 'center' as const,
+  },
   
   // Link Text
   link: {
@@ -214,6 +220,14 @@ export const ComponentStyles = StyleSheet.create({
     paddingVertical: Spacing[2],
     paddingHorizontal: Spacing[3],
     minHeight: 36,
+  },
+  buttonXs: {
+    borderRadius: BorderRadius.base,
+    paddingVertical: 0,
+    paddingHorizontal: 0,
+    minHeight: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   
   // Input Styles


### PR DESCRIPTION
## 概要
issue #51 の対応として、画像をタップして拡大表示できるコンポーネントを実装しました。

## 実装内容
- **ImageModalコンポーネント**: フルスクリーンで画像を表示するモーダルコンポーネントを新規作成
- **ImagePreviewコンポーネントの拡張**: 既存コンポーネントにタップ機能を追加
- **ジャーナル一覧での適用**: 自動的に画像プレビュー機能が利用可能

## 主な機能
- 画像をタップすると全画面表示でプレビュー
- モーダル外をタップまたは閉じるボタンでモーダル終了
- 既存の画像削除機能は維持
- レスポンシブ対応（画面サイズに合わせて調整）

## テスト計画
- [x] ジャーナル作成時の画像プレビュー動作確認
- [x] ジャーナル一覧での画像タップ動作確認
- [x] モーダルの開閉動作確認
- [x] ESLint通過確認
- [ ] iOS/Android実機での動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)