### PR TITLE
ジャーナル作成のためのSQLiteデータベース機能を追加

### DIFF
--- a/database/schema.ts
+++ b/database/schema.ts
@@ -19,8 +19,32 @@ export const CREATE_USERS_SYNCED_INDEX = `
   CREATE INDEX IF NOT EXISTS idx_users_synced ON users(synced);
 `;
 
+export const CREATE_JOURNAL_ENTRIES_TABLE = `
+  CREATE TABLE IF NOT EXISTS journal_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    content TEXT NOT NULL,
+    entry_date DATE NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    synced BOOLEAN DEFAULT 0,
+    last_modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  );
+`;
+
+export const CREATE_JOURNAL_ENTRIES_DATE_INDEX = `
+  CREATE INDEX IF NOT EXISTS idx_journal_entries_entry_date ON journal_entries(entry_date);
+`;
+
+export const CREATE_JOURNAL_ENTRIES_SYNCED_INDEX = `
+  CREATE INDEX IF NOT EXISTS idx_journal_entries_synced ON journal_entries(synced);
+`;
+
 export const SCHEMA_STATEMENTS = [
   CREATE_USERS_TABLE,
   CREATE_USERS_EMAIL_INDEX,
   CREATE_USERS_SYNCED_INDEX,
+  CREATE_JOURNAL_ENTRIES_TABLE,
+  CREATE_JOURNAL_ENTRIES_DATE_INDEX,
+  CREATE_JOURNAL_ENTRIES_SYNCED_INDEX,
 ] as const;

--- a/models/journal.ts
+++ b/models/journal.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const JournalEntrySchema = z.object({
+  id: z.number().int().positive(),
+  title: z.string().optional(),
+  content: z.string().min(1, 'Content is required'),
+  entry_date: z.string().date(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  synced: z.boolean(),
+  last_modified: z.string().datetime(),
+});
+
+export const CreateJournalEntrySchema = z.object({
+  title: z.string().optional(),
+  content: z.string().min(1, 'Content is required'),
+  entry_date: z.string().date(),
+});
+
+export const UpdateJournalEntrySchema = z.object({
+  title: z.string().optional(),
+  content: z.string().min(1, 'Content is required').optional(),
+  entry_date: z.string().date().optional(),
+});
+
+export type JournalEntry = z.infer<typeof JournalEntrySchema>;
+export type CreateJournalEntryData = z.infer<typeof CreateJournalEntrySchema>;
+export type UpdateJournalEntryData = z.infer<typeof UpdateJournalEntrySchema>;

--- a/services/journal-service.ts
+++ b/services/journal-service.ts
@@ -1,0 +1,121 @@
+import { executeQuery, fetchQuery } from '@/database/query';
+import { CreateJournalEntrySchema, UpdateJournalEntrySchema, JournalEntrySchema } from '@/models/journal';
+import type { JournalEntry, CreateJournalEntryData, UpdateJournalEntryData } from '@/models/journal';
+import type { DatabaseError } from '@/database/query';
+
+export async function createJournalEntry(entryData: CreateJournalEntryData): Promise<JournalEntry> {
+  const validatedData = CreateJournalEntrySchema.parse(entryData);
+  
+  const query = `
+    INSERT INTO journal_entries (title, content, entry_date, last_modified)
+    VALUES (?, ?, ?, datetime('now'))
+  `;
+  
+  const result = await executeQuery<{ insertId: number }>(
+    query,
+    [validatedData.title || null, validatedData.content, validatedData.entry_date]
+  );
+
+  return await getJournalEntry(result.insertId);
+}
+
+export async function getJournalEntry(id: number): Promise<JournalEntry> {
+  const query = 'SELECT * FROM journal_entries WHERE id = ?';
+  const entries = await fetchQuery<JournalEntry>(query, [id]);
+  
+  if (entries.length === 0) {
+    const error: DatabaseError = {
+      message: `Journal entry with id ${id} not found`,
+      code: 'JOURNAL_ENTRY_NOT_FOUND',
+    };
+    throw error;
+  }
+
+  return JournalEntrySchema.parse(entries[0]);
+}
+
+export async function getAllJournalEntries(): Promise<JournalEntry[]> {
+  const query = 'SELECT * FROM journal_entries ORDER BY entry_date DESC, created_at DESC';
+  const entries = await fetchQuery<JournalEntry>(query);
+  
+  return entries.map(entry => JournalEntrySchema.parse(entry));
+}
+
+export async function getJournalEntriesByDate(date: string): Promise<JournalEntry[]> {
+  const query = 'SELECT * FROM journal_entries WHERE entry_date = ? ORDER BY created_at DESC';
+  const entries = await fetchQuery<JournalEntry>(query, [date]);
+  
+  return entries.map(entry => JournalEntrySchema.parse(entry));
+}
+
+export async function getJournalEntriesByDateRange(startDate: string, endDate: string): Promise<JournalEntry[]> {
+  const query = `
+    SELECT * FROM journal_entries 
+    WHERE entry_date >= ? AND entry_date <= ? 
+    ORDER BY entry_date DESC, created_at DESC
+  `;
+  const entries = await fetchQuery<JournalEntry>(query, [startDate, endDate]);
+  
+  return entries.map(entry => JournalEntrySchema.parse(entry));
+}
+
+export async function updateJournalEntry(id: number, entryData: UpdateJournalEntryData): Promise<JournalEntry> {
+  const validatedData = UpdateJournalEntrySchema.parse(entryData);
+  
+  const updateFields = Object.keys(validatedData).filter(
+    key => validatedData[key as keyof UpdateJournalEntryData] !== undefined
+  );
+  
+  if (updateFields.length === 0) {
+    return await getJournalEntry(id);
+  }
+
+  const setClause = updateFields.map(field => `${field} = ?`).join(', ');
+  const values = updateFields.map(field => validatedData[field as keyof UpdateJournalEntryData]);
+  
+  const query = `
+    UPDATE journal_entries 
+    SET ${setClause}, updated_at = datetime('now'), last_modified = datetime('now'), synced = 0
+    WHERE id = ?
+  `;
+  
+  await executeQuery(query, [...values, id]);
+  return await getJournalEntry(id);
+}
+
+export async function deleteJournalEntry(id: number): Promise<void> {
+  const query = 'DELETE FROM journal_entries WHERE id = ?';
+  const result = await executeQuery<{ changes: number }>(query, [id]);
+  
+  if (result.changes === 0) {
+    const error: DatabaseError = {
+      message: `Journal entry with id ${id} not found`,
+      code: 'JOURNAL_ENTRY_NOT_FOUND',
+    };
+    throw error;
+  }
+}
+
+export async function getJournalEntriesNeedingSync(): Promise<JournalEntry[]> {
+  const query = 'SELECT * FROM journal_entries WHERE synced = 0 ORDER BY last_modified ASC';
+  const entries = await fetchQuery<JournalEntry>(query);
+  
+  return entries.map(entry => JournalEntrySchema.parse(entry));
+}
+
+export async function markJournalEntryAsSynced(id: number): Promise<void> {
+  const query = 'UPDATE journal_entries SET synced = 1 WHERE id = ?';
+  await executeQuery(query, [id]);
+}
+
+export async function searchJournalEntries(searchTerm: string): Promise<JournalEntry[]> {
+  const query = `
+    SELECT * FROM journal_entries 
+    WHERE content LIKE ? OR title LIKE ?
+    ORDER BY entry_date DESC, created_at DESC
+  `;
+  const likePattern = `%${searchTerm}%`;
+  const entries = await fetchQuery<JournalEntry>(query, [likePattern, likePattern]);
+  
+  return entries.map(entry => JournalEntrySchema.parse(entry));
+}


### PR DESCRIPTION
## 概要

ジャーナルエントリの作成・管理のためのSQLiteデータベース機能を実装しました。

## 実装内容

- **ジャーナルエントリのZodスキーマ定義** (`models/journal.ts`)
  - JournalEntry、CreateJournalEntryData、UpdateJournalEntryDataの型定義
  - バリデーション機能付きのスキーマ

- **SQLiteテーブル定義** (`database/schema.ts`)
  - journal_entriesテーブルの追加
  - entry_dateとsynced フィールドのインデックス追加
  - 同期機能に対応したデータ構造

- **ジャーナルサービス** (`services/journal-service.ts`)
  - 完全なCRUD操作（作成、読み取り、更新、削除）
  - 日付別・日付範囲でのエントリ取得
  - テキスト検索機能
  - 同期状態管理機能

## テスト計画

- [x] TypeScriptコンパイルエラーのチェック
- [x] ESLintによるコード品質チェック
- [ ] 実際のデータベース作成・操作テスト
- [ ] ジャーナルエントリのCRUD操作テスト
- [ ] 検索機能のテスト

## 影響範囲

- 新規ファイルの追加のみで既存コードへの影響なし
- データベーススキーマの拡張（後方互換性あり）

🤖 Generated with [Claude Code](https://claude.ai/code)