### PR TITLE
hotfix: フルスクリーンダイアログでSafeAreaViewの効果を修正

### DIFF
--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -101,7 +101,13 @@ export function DialogContent({
       {...rest}
     >
       {/* Fixed Header */}
-      <View style={{ position: "absolute", top: 0, left: 0, right: 0, zIndex: 1 }}>
+      <View style={{ 
+        position: "absolute", 
+        top: isFullscreen ? 0 : 0, 
+        left: 0, 
+        right: 0, 
+        zIndex: 1 
+      }}>
         {headerElement}
       </View>
       
@@ -127,7 +133,7 @@ export function DialogContent({
       onRequestClose={() => onOpenChange(false)}
     >
       {isFullscreen ? (
-        <SafeAreaView style={{ flex: 1 }}>
+        <SafeAreaView style={{ flex: 1 }} edges={['top', 'left', 'right', 'bottom']}>
           {content}
         </SafeAreaView>
       ) : (


### PR DESCRIPTION
## 問題
フルスクリーンダイアログでSafeAreaViewが効いていない

## 修正内容
- SafeAreaViewの`edges`プロパティを明示的に指定
- 全てのエッジ（top, left, right, bottom）で安全領域を確保
- フルスクリーン表示時のノッチ・ステータスバー対応を改善

## テスト計画
- [x] ESLintチェック
- [ ] フルスクリーンダイアログの表示確認（ノッチ・ステータスバー領域）
- [ ] 各種デバイスでの安全領域確認

## 影響範囲
- フルスクリーンvariantのDialogコンポーネントのみ
- 既存のdefault variantには影響なし

🤖 Generated with [Claude Code](https://claude.ai/code)