### PR TITLE
shadcn-like Avatarコンポーネントの実装とホーム画面への追加

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -7,6 +7,7 @@ import { ThemedText } from '@/components/themed-text';
 import { WeeklyCalendar } from '@/features/journal';
 import { Card, CardContent, CardHeader, CardTitle, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Avatar, AvatarGroup } from '@/components/ui/avatar';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { SegmentDetailDialog } from '@/components/segment-detail-dialog';
 import { Textarea } from '@/components/ui/textarea';
@@ -83,6 +84,15 @@ export default function HomeScreen() {
       description: '元気づけてくれる',
       illustration: '🌟',
     },
+  ];
+
+  // Mock avatar data for demonstration
+  const mockAvatars = [
+    { id: '1', name: 'Yuki Tanaka', src: undefined },
+    { id: '2', name: 'Hiroshi Sato', src: undefined },
+    { id: '3', name: 'Akiko Yamada', src: undefined },
+    { id: '4', name: 'Kenji Nakamura', src: undefined },
+    { id: '5', name: 'Misaki Ito', src: undefined },
   ];
 
   const mockJournalDates = journalEntries.map(entry => entry.date);
@@ -192,13 +202,22 @@ export default function HomeScreen() {
                   {entry.content}
                 </ThemedText>
               </CardContent>
-              <CardFooter>
+              <CardFooter style={styles.journalCardFooter}>
                 <ThemedText 
                   type="defaultSemiBold" 
                   style={[styles.journalDate, { color: theme.text.secondary }]}
                 >
                   {formatDate(entry.date)}
                 </ThemedText>
+                <AvatarGroup max={4} spacing={-Spacing[1]}>
+                  {mockAvatars.slice(0, 5).map((avatar) => (
+                    <Avatar
+                      key={avatar.id}
+                      fallback={avatar.name}
+                      size="sm"
+                    />
+                  ))}
+                </AvatarGroup>
               </CardFooter>
             </Card>
           ))}
@@ -341,8 +360,13 @@ const styles = StyleSheet.create({
   journalCardContent: {
     paddingBottom: 0,
   },
+  journalCardFooter: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
   journalDate: {
-    marginBottom: Spacing[2],
+    marginBottom: 0,
   },
   journalContent: {
     lineHeight: 22,

--- a/components/ui/avatar.tsx
+++ b/components/ui/avatar.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { View, Image, type ViewStyle, type ImageStyle } from 'react-native';
+import { ThemedText } from '@/components/themed-text';
+import { useTheme } from '@/hooks/use-theme';
+import { BorderRadius, Spacing, Typography, ColorPalette } from '@/constants/design-tokens';
+
+export type AvatarSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' | '2xl';
+
+export type AvatarProps = {
+  src?: string;
+  alt?: string;
+  fallback?: string;
+  size?: AvatarSize;
+  style?: ViewStyle;
+};
+
+export function Avatar({
+  src,
+  alt,
+  fallback,
+  size = 'md',
+  style,
+}: AvatarProps) {
+  const { theme } = useTheme();
+  
+  const getSizeStyles = (): ViewStyle => {
+    switch (size) {
+      case 'xs':
+        return {
+          width: 24,
+          height: 24,
+          borderRadius: BorderRadius.full,
+        };
+      case 'sm':
+        return {
+          width: 32,
+          height: 32,
+          borderRadius: BorderRadius.full,
+        };
+      case 'md':
+        return {
+          width: 40,
+          height: 40,
+          borderRadius: BorderRadius.full,
+        };
+      case 'lg':
+        return {
+          width: 48,
+          height: 48,
+          borderRadius: BorderRadius.full,
+        };
+      case 'xl':
+        return {
+          width: 56,
+          height: 56,
+          borderRadius: BorderRadius.full,
+        };
+      case '2xl':
+        return {
+          width: 64,
+          height: 64,
+          borderRadius: BorderRadius.full,
+        };
+      default:
+        return {
+          width: 40,
+          height: 40,
+          borderRadius: BorderRadius.full,
+        };
+    }
+  };
+
+  const getFallbackTextSize = (): number => {
+    switch (size) {
+      case 'xs':
+        return Typography.fontSize.xs;
+      case 'sm':
+        return Typography.fontSize.sm;
+      case 'md':
+        return Typography.fontSize.base;
+      case 'lg':
+        return Typography.fontSize.lg;
+      case 'xl':
+        return Typography.fontSize.xl;
+      case '2xl':
+        return Typography.fontSize['2xl'];
+      default:
+        return Typography.fontSize.base;
+    }
+  };
+
+  const sizeStyles = getSizeStyles();
+  const fallbackTextSize = getFallbackTextSize();
+
+  const containerStyle: ViewStyle = {
+    ...sizeStyles,
+    backgroundColor: theme.background.secondary,
+    borderWidth: 1,
+    borderColor: theme.border.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  };
+
+  const imageStyle: ImageStyle = {
+    width: '100%',
+    height: '100%',
+    borderRadius: sizeStyles.borderRadius as number,
+  };
+
+  // Get initials from fallback text
+  const getInitials = (text: string): string => {
+    if (!text) return '';
+    
+    const words = text.trim().split(' ');
+    if (words.length === 1) {
+      return words[0].charAt(0).toUpperCase();
+    }
+    
+    return words
+      .slice(0, 2)
+      .map(word => word.charAt(0).toUpperCase())
+      .join('');
+  };
+
+  return (
+    <View style={[containerStyle, style]}>
+      {src ? (
+        <Image
+          source={{ uri: src }}
+          style={imageStyle}
+          accessibilityLabel={alt}
+        />
+      ) : (
+        <ThemedText
+          style={{
+            fontSize: fallbackTextSize,
+            fontWeight: Typography.fontWeight.medium,
+            color: theme.text.primary,
+          }}
+        >
+          {getInitials(fallback || alt || '')}
+        </ThemedText>
+      )}
+    </View>
+  );
+}
+
+export type AvatarGroupProps = {
+  children: React.ReactNode;
+  spacing?: number;
+  max?: number;
+  style?: ViewStyle;
+};
+
+export function AvatarGroup({
+  children,
+  spacing = -Spacing[2],
+  max,
+  style,
+}: AvatarGroupProps) {
+  const { theme } = useTheme();
+  
+  const childrenArray = React.Children.toArray(children);
+  const displayChildren = max ? childrenArray.slice(0, max) : childrenArray;
+  const remainingCount = max && childrenArray.length > max ? childrenArray.length - max : 0;
+
+  return (
+    <View style={[{ flexDirection: 'row', alignItems: 'center' }, style]}>
+      {displayChildren.map((child, index) => (
+        <View
+          key={index}
+          style={{
+            marginLeft: index > 0 ? spacing : 0,
+            zIndex: displayChildren.length - index,
+          }}
+        >
+          {child}
+        </View>
+      ))}
+      {remainingCount > 0 && (
+        <View
+          style={{
+            marginLeft: spacing,
+            zIndex: 0,
+          }}
+        >
+          <Avatar
+            fallback={`+${remainingCount}`}
+            size="md"
+            style={{
+              backgroundColor: ColorPalette.neutral[200],
+              borderColor: theme.border.primary,
+            }}
+          />
+        </View>
+      )}
+    </View>
+  );
+}

--- a/components/ui/index.ts
+++ b/components/ui/index.ts
@@ -2,6 +2,7 @@
  * UI Components Exports
  */
 
+export { Avatar, AvatarGroup } from './avatar';
 export { Button } from './button';
 export { Card } from './card';
 export { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter, DialogClose } from './dialog';


### PR DESCRIPTION
## 概要

shadcn UIライブラリに似たAPIを持つAvatarコンポーネントを実装し、ホーム画面のジャーナルカードに統合しました。

## 実装内容

### 新しいコンポーネント
- **Avatar**: 単一のアバター表示コンポーネント
  - 画像表示とフォールバック（イニシャル）表示をサポート
  - 6つのサイズバリエーション（xs, sm, md, lg, xl, 2xl）
  - デザインシステムトークンを使用した一貫性のあるスタイリング
  
- **AvatarGroup**: 複数のアバターを重ねて表示するコンポーネント
  - 最大表示数制限機能（max prop）
  - カスタマイズ可能な重なり幅（spacing prop）
  - 表示しきれないアバター数の表示機能

### UI統合
- ホーム画面のジャーナルカード下部にアバターグループを追加
- 日付表示とアバターを横並びで配置するレイアウト調整
- モックデータとして5つのアバターを表示（最大4つまで表示、+1で残数表示）

## 技術仕様

### コンポーネントAPI
```typescript
// Avatar
<Avatar 
  src="画像URL" 
  fallback="名前" 
  size="md" 
  alt="アクセシビリティ用説明"
/>

// AvatarGroup  
<AvatarGroup max={4} spacing={-8}>
  <Avatar fallback="YT" />
  <Avatar fallback="HS" />
  {/* ... */}
</AvatarGroup>
```

### 特徴
- TypeScript完全対応
- デザインシステムとの統合
- React Native対応
- アクセシビリティサポート
- shadcn UI互換API

## テスト計画

- [x] ESLintチェック通過
- [x] TypeScript型チェック（Avatar関連）
- [ ] iOS/Androidでの表示確認
- [ ] 各サイズバリエーションの表示確認
- [ ] AvatarGroupの重なり表示確認
- [ ] フォールバック表示の確認

## 影響範囲

- 新規コンポーネントの追加のため、既存機能への影響なし
- ホーム画面のジャーナルカードレイアウト微調整
- デザインシステムトークンの活用により一貫性を保持

🤖 Generated with [Claude Code](https://claude.ai/code)