### PR TITLE
feat: ジャーナルAPI CRUD機能を実装

### DIFF
--- a/packages/api/migrations/0001_dark_payback.sql
+++ b/packages/api/migrations/0001_dark_payback.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `journals` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`title` text NOT NULL,
+	`content` text NOT NULL,
+	`date` text NOT NULL,
+	`author_id` integer NOT NULL,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP,
+	FOREIGN KEY (`author_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);

--- a/packages/api/migrations/meta/0001_snapshot.json
+++ b/packages/api/migrations/meta/0001_snapshot.json
@@ -1,0 +1,224 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "600f15b7-7c39-4bd7-a1d3-87d658ee8587",
+  "prevId": "b2b07c7b-8fd6-4831-a182-080d80e11d10",
+  "tables": {
+    "journals": {
+      "name": "journals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journals_author_id_users_id_fk": {
+          "name": "journals_author_id_users_id_fk",
+          "tableFrom": "journals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_author_id_users_id_fk": {
+          "name": "posts_author_id_users_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/api/migrations/meta/_journal.json
+++ b/packages/api/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1752391406221,
       "tag": "0000_last_nightcrawler",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1752990865865,
+      "tag": "0001_dark_payback",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { cors } from 'hono/cors'
-import { users, posts } from './routes'
+import { users, posts, journals } from './routes'
 import { AppError } from '@soyokaze/schemas/api/errors'
 
 type Bindings = {
@@ -20,6 +20,7 @@ app.get("/", (c) => {
 
 app.route("/users", users);
 app.route("/posts", posts);
+app.route("/journals", journals);
 
 app.onError((err, c) => {
   console.error(err)

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -1,2 +1,3 @@
 export { default as users } from "./users";
 export { default as posts } from "./posts";
+export { default as journals } from "./journals";

--- a/packages/api/src/routes/journals.ts
+++ b/packages/api/src/routes/journals.ts
@@ -1,0 +1,219 @@
+import { Hono } from 'hono'
+import { zValidator } from '@hono/zod-validator'
+import { eq, and, desc, count } from 'drizzle-orm'
+import { sql } from 'drizzle-orm'
+
+import { db } from '../db'
+import { journals, users } from '@repo/schemas/db/schema'
+import {
+  CreateJournalSchema,
+  UpdateJournalSchema,
+  JournalListQuerySchema,
+  IdParamSchema,
+} from '@repo/schemas/api/validators'
+import { AppError, NotFoundError, ValidationError } from '@repo/schemas/api/errors'
+import type { Bindings } from '../types'
+
+const app = new Hono<{ Bindings: Bindings }>()
+
+// GET /journals - 一覧取得
+app.get('/', zValidator('query', JournalListQuerySchema), async (c) => {
+  try {
+    const query = c.req.valid('query')
+    const { page, limit, authorId, date } = query
+
+    // WHERE条件を動的に構築
+    const whereConditions = []
+    if (authorId) {
+      whereConditions.push(eq(journals.authorId, authorId))
+    }
+    if (date) {
+      whereConditions.push(eq(journals.date, date))
+    }
+
+    // ジャーナル一覧取得
+    const journalList = await db
+      .select()
+      .from(journals)
+      .where(whereConditions.length > 0 ? and(...whereConditions) : undefined)
+      .orderBy(desc(journals.createdAt))
+      .limit(limit)
+      .offset((page - 1) * limit)
+
+    // 総件数取得
+    const [{ count: total }] = await db
+      .select({ count: count() })
+      .from(journals)
+      .where(whereConditions.length > 0 ? and(...whereConditions) : undefined)
+
+    return c.json({
+      success: true,
+      data: {
+        journals: journalList,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+        },
+      },
+    })
+  } catch (error) {
+    console.error('Error fetching journals:', error)
+    throw new AppError('Failed to fetch journals', 'FETCH_ERROR', 500)
+  }
+})
+
+// GET /journals/:id - 詳細取得
+app.get('/:id', zValidator('param', IdParamSchema), async (c) => {
+  try {
+    const { id } = c.req.valid('param')
+
+    const [journal] = await db
+      .select()
+      .from(journals)
+      .where(eq(journals.id, id))
+      .limit(1)
+
+    if (!journal) {
+      throw new NotFoundError('Journal')
+    }
+
+    return c.json({
+      success: true,
+      data: journal,
+    })
+  } catch (error) {
+    if (error instanceof AppError) {
+      throw error
+    }
+    console.error('Error fetching journal:', error)
+    throw new AppError('Failed to fetch journal', 'FETCH_ERROR', 500)
+  }
+})
+
+// POST /journals - 作成
+app.post('/', zValidator('json', CreateJournalSchema), async (c) => {
+  try {
+    const journalData = c.req.valid('json')
+
+    // 作成者の存在確認
+    const [author] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, journalData.authorId))
+      .limit(1)
+
+    if (!author) {
+      throw new ValidationError('Author does not exist')
+    }
+
+    // ジャーナル作成
+    const [newJournal] = await db
+      .insert(journals)
+      .values({
+        title: journalData.title,
+        content: journalData.content,
+        date: journalData.date,
+        authorId: journalData.authorId,
+      })
+      .returning()
+
+    return c.json({
+      success: true,
+      data: newJournal,
+    }, 201)
+  } catch (error) {
+    if (error instanceof AppError) {
+      throw error
+    }
+    console.error('Error creating journal:', error)
+    throw new AppError('Failed to create journal', 'CREATE_ERROR', 500)
+  }
+})
+
+// PUT /journals/:id - 更新
+app.put('/:id', 
+  zValidator('param', IdParamSchema),
+  zValidator('json', UpdateJournalSchema),
+  async (c) => {
+    try {
+      const { id } = c.req.valid('param')
+      const updateData = c.req.valid('json')
+
+      // ジャーナルの存在確認
+      const [existingJournal] = await db
+        .select()
+        .from(journals)
+        .where(eq(journals.id, id))
+        .limit(1)
+
+      if (!existingJournal) {
+        throw new NotFoundError('Journal')
+      }
+
+      // 更新データに updatedAt を追加
+      const updateValues = {
+        ...updateData,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      }
+
+      // ジャーナル更新
+      const [updatedJournal] = await db
+        .update(journals)
+        .set(updateValues)
+        .where(eq(journals.id, id))
+        .returning()
+
+      return c.json({
+        success: true,
+        data: updatedJournal,
+      })
+    } catch (error) {
+      if (error instanceof AppError) {
+        throw error
+      }
+      console.error('Error updating journal:', error)
+      throw new AppError('Failed to update journal', 'UPDATE_ERROR', 500)
+    }
+  }
+)
+
+// DELETE /journals/:id - 削除
+app.delete('/:id', zValidator('param', IdParamSchema), async (c) => {
+  try {
+    const { id } = c.req.valid('param')
+
+    // ジャーナルの存在確認
+    const [existingJournal] = await db
+      .select()
+      .from(journals)
+      .where(eq(journals.id, id))
+      .limit(1)
+
+    if (!existingJournal) {
+      throw new NotFoundError('Journal')
+    }
+
+    // ジャーナル削除
+    await db
+      .delete(journals)
+      .where(eq(journals.id, id))
+
+    return c.json({
+      success: true,
+      data: {
+        message: 'Journal deleted successfully',
+        deletedId: id,
+      },
+    })
+  } catch (error) {
+    if (error instanceof AppError) {
+      throw error
+    }
+    console.error('Error deleting journal:', error)
+    throw new AppError('Failed to delete journal', 'DELETE_ERROR', 500)
+  }
+})
+
+export default app

--- a/packages/schemas/src/api/types.ts
+++ b/packages/schemas/src/api/types.ts
@@ -1,9 +1,28 @@
 import { z } from 'zod'
-import { CreateUserSchema, CreatePostSchema, PaginationSchema } from './validators'
+import { 
+  CreateUserSchema, 
+  CreatePostSchema, 
+  PaginationSchema,
+  CreateJournalSchema,
+  UpdateJournalSchema,
+  JournalListQuerySchema
+} from './validators'
+import type { InferSelectModel, InferInsertModel } from 'drizzle-orm'
+import { journals } from '../db/schema'
 
 export type CreateUserInput = z.infer<typeof CreateUserSchema>
 export type CreatePostInput = z.infer<typeof CreatePostSchema>
 export type PaginationQuery = z.infer<typeof PaginationSchema>
+
+// Journal validation types
+export type CreateJournalInput = z.infer<typeof CreateJournalSchema>
+export type UpdateJournalInput = z.infer<typeof UpdateJournalSchema>
+export type JournalListQuery = z.infer<typeof JournalListQuerySchema>
+
+// Journal types using Drizzle ORM inference
+export type Journal = InferSelectModel<typeof journals>
+export type NewJournal = InferInsertModel<typeof journals>
+export type JournalUpdate = Partial<Pick<Journal, 'title' | 'content' | 'date'>>
 
 export type PaginatedResponse<T> = {
   data: T[]

--- a/packages/schemas/src/api/validators.ts
+++ b/packages/schemas/src/api/validators.ts
@@ -20,3 +20,31 @@ export const PaginationSchema = z.object({
 export const IdParamSchema = z.object({
   id: z.coerce.number().min(1),
 })
+
+// Journal validators
+export const DateStringSchema = z.string().regex(
+  /^\d{4}-\d{2}-\d{2}$/,
+  'Date must be in YYYY-MM-DD format'
+)
+
+export const CreateJournalSchema = z.object({
+  title: z.string().min(1).max(200),
+  content: z.string().min(1),
+  date: DateStringSchema,
+  authorId: z.number().int().positive(),
+})
+
+export const UpdateJournalSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  content: z.string().min(1).optional(),
+  date: DateStringSchema.optional(),
+}).refine(data => Object.keys(data).length > 0, {
+  message: "At least one field must be provided for update",
+})
+
+export const JournalListQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+  authorId: z.coerce.number().int().positive().optional(),
+  date: DateStringSchema.optional(),
+})

--- a/packages/schemas/src/db/schema.ts
+++ b/packages/schemas/src/db/schema.ts
@@ -18,3 +18,13 @@ export const posts = sqliteTable('posts', {
   createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
   updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`),
 })
+
+export const journals = sqliteTable('journals', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  title: text('title').notNull(),
+  content: text('content').notNull(),
+  date: text('date').notNull(),
+  authorId: integer('author_id').notNull().references(() => users.id),
+  createdAt: text('created_at').default(sql`CURRENT_TIMESTAMP`),
+  updatedAt: text('updated_at').default(sql`CURRENT_TIMESTAMP`),
+})


### PR DESCRIPTION
- journalsテーブルをデータベーススキーマに追加
- ジャーナル作成・編集・削除・一覧取得・詳細取得のAPIエンドポイントを実装
- Zodスキーマによるバリデーション機能を追加
- ページネーション・フィルタ機能対応
- 既存のエラーハンドリングパターンと統合

🤖 Generated with [Claude Code](https://claude.ai/code)